### PR TITLE
Add X12 to FHIR Endpoint

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,42 @@
+# Orchestrate SDK
+
+The Orchestrate SDK is a TypeScript and JavaScript library for interacting with the Orchestrate API at <https://api.rosetta.careevolution.com>.
+
+Full documentation of the API is available at <https://rosetta-api.docs.careevolution.com/>.
+
+## Installation
+
+TypeScript:
+
+```bash
+npm install @careevolution/orchestrate
+```
+
+Python:
+
+```bash
+pip install orchestrate-api
+```
+
+## Usage
+
+TypeScript:
+
+```typescript
+import { OrchestrateApi } from '@careevolution/orchestrate';
+
+orchestrate = new OrchestrateApi({apiKey: "your-api-key"});
+await orchestrate.classifyCondition({
+  code="119981000146107",
+  system="SNOMED",
+});
+```
+
+Python:
+
+```python
+from orchestrate import OrchestrateApi
+
+api = OrchestrateApi(api_key="your-api-key")
+api.classify_condition(code="119981000146107", system="SNOMED")
+```

--- a/python/orchestrate/convert.py
+++ b/python/orchestrate/convert.py
@@ -9,3 +9,5 @@ ConvertCdaToPdfResponse = bytes
 ConvertFhirR4ToCdaResponse = str
 
 ConvertFhirR4ToOmopResponse = bytes
+
+ConvertX12ToFhirR4Response = Bundle

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -435,6 +435,79 @@ def test_convert_combined_fhir_r4_bundles_with_person_should_combine():
     assert patient_resource["id"] == "1234"
 
 
+_X12_DOCUMENT = """ISA*00*          *00*          *ZZ*SUBMITTERID    *ZZ*RECEIVERID     *230616*1145*^*00501*000000001*0*T*:~
+GS*HC*SENDERCODE*RECEIVERCODE*20230627*11301505*123456789*X*005010X222A1~
+ST*837*0034*005010X223A1~
+BHT*0019*00*3920394930203*20100816*1615*CH~
+NM1*41*2*HOWDEE HOSPITAL*****46*0123456789~
+PER*IC*BETTY RUBBLE*TE*9195551111~
+NM1*40*2*BCBSNC*****46*987654321~
+HL*1**20*1~
+NM1*85*2*HOWDEE HOSPITAL*****XX*1245011012~
+N3*123 HOWDEE BLVD~
+N4*DURHAM*NC*27701~
+REF*EI*123456789~
+PER*IC*WILMA RUBBLE*TE*9195551111*FX*6145551212~
+HL*2*1*22*0~
+SBR*P*18*XYZ1234567******BL~
+NM1*IL*1*DOUGH*MARY****MI*24672148306~
+N3*BOX 12312~
+N4*DURHAM*NC*27715~
+DMG*D8*19670807*F~
+NM1*PR*2*BCBSNC*****PI*987654321~
+CLM*2235057*200***13:A:1***A**Y*Y~
+DTP*434*RD8*20100730-20100730~
+CL1*1*9*01~
+REF*F8*ASD0000123~
+HI*BK:25000~
+HI*BF:78901~
+HI*BR:4491:D8:20100730~
+HI*BH:41:D8:20100501*BH:27:D8:20100715*BH:33:D8:20100415*BH:C2:D8:20100410~
+HI*BE:30:::20~
+HI*BG:01~
+NM1*71*1*SMITH*ELIZABETH*AL***34*243898989~
+REF*1G*P97777~
+LX*1~
+SV2*0300*HC:81000*120*UN*1~
+DTP*472*D8*20100730~
+LX*2~
+SV2*0320*HC:76092*50*UN*1~
+DTP*472*D8*20100730~
+LX*3~
+SV2*0270*HC:J1120*30*UN*1~
+DTP*472*D8*20100730~
+SE*38*0034~
+GE*1*30~
+IEA*1*000000031~
+"""
+
+
+def test_convert_x12_to_fhir_r4_should_return_a_bundle():
+    result = TEST_API.convert_x12_to_fhir_r4(x12_document=_X12_DOCUMENT)
+
+    assert result is not None
+    assert result["resourceType"] == "Bundle"
+    assert len(result["entry"]) > 0
+
+
+def test_convert_x12_to_fhir_r4_with_patient_should_return_a_bundle():
+    result = TEST_API.convert_x12_to_fhir_r4(
+        x12_document=_X12_DOCUMENT, patient_id="1234"
+    )
+
+    assert result is not None
+    assert result["resourceType"] == "Bundle"
+    assert len(result["entry"]) > 0
+    patient_resource = next(
+        (
+            entry["resource"]
+            for entry in result["entry"]
+            if entry["resource"]["resourceType"] == "Patient"
+        )
+    )
+    assert patient_resource["id"] == "1234"
+
+
 def test_get_fhir_r4_code_system_should_return_a_code_system():
     result = TEST_API.get_fhir_r4_code_system(code_system="SNOMED")
 

--- a/typescript/src/api.ts
+++ b/typescript/src/api.ts
@@ -11,6 +11,8 @@ import {
   ConvertFhirR4ToOmopResponse,
   ConvertHl7ToFhirR4Request,
   ConvertHl7ToFhirR4Response,
+  ConvertX12ToFhirR4Request,
+  ConvertX12ToFhirR4Response,
 } from "./convert";
 import { InsightRiskProfileRequest, InsightRiskProfileResponse } from "./insight";
 import {
@@ -314,10 +316,7 @@ export class OrchestrateApi {
     const headers = {
       "Content-Type": "text/plain",
     } as { [key: string]: string; };
-    let route = "/convert/v1/hl7tofhirr4";
-    if (request.patientID) {
-      route += `/${encodeURIComponent(request.patientID)}`;
-    }
+    const route = this.getIDDependentRoute("/convert/v1/hl7tofhirr4", request.patientID);
     return this.rosettaApi.post(route, request.hl7Message, headers);
   }
 
@@ -330,10 +329,7 @@ export class OrchestrateApi {
     const headers = {
       "Content-Type": "application/xml",
     } as { [key: string]: string; };
-    let route = "/convert/v1/cdatofhirr4";
-    if (request.patientID) {
-      route += `/${encodeURIComponent(request.patientID)}`;
-    }
+    const route = this.getIDDependentRoute("/convert/v1/cdatofhirr4", request.patientID);
     return this.rosettaApi.post(route, request.cda, headers);
   }
 
@@ -383,11 +379,28 @@ export class OrchestrateApi {
     const headers = {
       "Content-Type": "application/x-ndjson",
     } as { [key: string]: string; };
-    let route = "/convert/v1/combinefhirr4bundles";
-    if (request.personID) {
-      route += `/${encodeURIComponent(request.personID)}`;
-    }
+    const route = this.getIDDependentRoute("/convert/v1/combinefhirr4bundles", request.personID);
     return this.rosettaApi.post(route, request.fhirBundles, headers);
+  }
+
+  /**
+   * Converts an X12 document into a FHIR R4 bundle.
+   * @param request A standard version 5010 X12 document
+   * @returns A FHIR R4 Bundle containing the clinical data parsed out of the X12 messages
+   */
+  convertX12ToFhirR4(request: ConvertX12ToFhirR4Request): Promise<ConvertX12ToFhirR4Response> {
+    const headers = {
+      "Content-Type": "text/plain",
+    } as { [key: string]: string; };
+    const route = this.getIDDependentRoute("/convert/v1/x12tofhirr4", request.patientID);
+    return this.rosettaApi.post(route, request.x12Document, headers);
+  }
+
+  private getIDDependentRoute(route: string, id?: string): string {
+    if (id) {
+      return `${route}/${encodeURIComponent(id)}`;
+    }
+    return route;
   }
 
   /**
@@ -399,6 +412,7 @@ export class OrchestrateApi {
     const route = `/terminology/v1/fhir/r4/codesystem/${encodeURIComponent(request.codeSystem)}?_summary=true`;
     return this.rosettaApi.get(route);
   }
+
 }
 
 class RosettaApi {

--- a/typescript/src/convert.ts
+++ b/typescript/src/convert.ts
@@ -48,3 +48,10 @@ export function generateConvertCombinedFhirBundlesRequestFromBundles(fhirBundles
 }
 
 export type ConvertCombineFhirR4BundlesResponse = Bundle;
+
+export type ConvertX12ToFhirR4Request = {
+  x12Document: string;
+  patientID?: string;
+};
+
+export type ConvertX12ToFhirR4Response = Bundle;

--- a/typescript/tests/api.test.ts
+++ b/typescript/tests/api.test.ts
@@ -176,6 +176,52 @@ const fhir = {
   ]
 } as Bundle;
 
+const x12Document = (`ISA*00*          *00*          *ZZ*SUBMITTERID    *ZZ*RECEIVERID     *230616*1145*^*00501*000000001*0*T*:~
+GS*HC*SENDERCODE*RECEIVERCODE*20230627*11301505*123456789*X*005010X222A1~
+ST*837*0034*005010X223A1~
+BHT*0019*00*3920394930203*20100816*1615*CH~
+NM1*41*2*HOWDEE HOSPITAL*****46*0123456789~
+PER*IC*BETTY RUBBLE*TE*9195551111~
+NM1*40*2*BCBSNC*****46*987654321~
+HL*1**20*1~
+NM1*85*2*HOWDEE HOSPITAL*****XX*1245011012~
+N3*123 HOWDEE BLVD~
+N4*DURHAM*NC*27701~
+REF*EI*123456789~
+PER*IC*WILMA RUBBLE*TE*9195551111*FX*6145551212~
+HL*2*1*22*0~
+SBR*P*18*XYZ1234567******BL~
+NM1*IL*1*DOUGH*MARY****MI*24672148306~
+N3*BOX 12312~
+N4*DURHAM*NC*27715~
+DMG*D8*19670807*F~
+NM1*PR*2*BCBSNC*****PI*987654321~
+CLM*2235057*200***13:A:1***A**Y*Y~
+DTP*434*RD8*20100730-20100730~
+CL1*1*9*01~
+REF*F8*ASD0000123~
+HI*BK:25000~
+HI*BF:78901~
+HI*BR:4491:D8:20100730~
+HI*BH:41:D8:20100501*BH:27:D8:20100715*BH:33:D8:20100415*BH:C2:D8:20100410~
+HI*BE:30:::20~
+HI*BG:01~
+NM1*71*1*SMITH*ELIZABETH*AL***34*243898989~
+REF*1G*P97777~
+LX*1~
+SV2*0300*HC:81000*120*UN*1~
+DTP*472*D8*20100730~
+LX*2~
+SV2*0320*HC:76092*50*UN*1~
+DTP*472*D8*20100730~
+LX*3~
+SV2*0270*HC:J1120*30*UN*1~
+DTP*472*D8*20100730~
+SE*38*0034~
+GE*1*30~
+IEA*1*000000031~
+`);
+
 describe("classify condition", () => {
   it("should classify with URL", async () => {
     const result = await orchestrate.classifyCondition({
@@ -481,6 +527,30 @@ describe("convert fhir r4 to omop", () => {
     });
     expect(result).toBeDefined();
     expect(result).toContain("PROCESSING_LOG.csv");
+  });
+});
+
+describe("convert x12 to fhir r4", () => {
+  it("should convert x12", async () => {
+    const result = await orchestrate.convertX12ToFhirR4({
+      x12Document: x12Document
+    });
+    expect(result).toBeDefined();
+    expect(result.resourceType).toBe("Bundle");
+    expect(result.entry?.length).toBeGreaterThan(0);
+  });
+
+  it("should convert x12 with patient", async () => {
+    const result = await orchestrate.convertX12ToFhirR4({
+      x12Document: x12Document,
+      patientID: "1234"
+    });
+    expect(result).toBeDefined();
+    expect(result.resourceType).toBe("Bundle");
+    expect(result.entry?.length).toBeGreaterThan(0);
+    const patientResource = result.entry?.find((entry) => entry.resource?.resourceType === "Patient");
+    expect(patientResource).toBeDefined();
+    expect(patientResource?.resource?.id).toBe("1234");
   });
 });
 


### PR DESCRIPTION
## Description of Changes

Adds `/convert/v1/x12tofhir/:patientID` endpoint. Documentation for this endpoint is currently in PR.

## Security

**REMINDER: All file contents are public.**

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note: No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] My changes do not introduce any security risks, or any such risks have been properly mitigated.

This endpoint follows the same basic pattern as other convert endpoints, particularly other `text/plain` endpoints. The only difference is that the input is a single X12 message instead of a bundle of X12 messages. The endpoint is not publicly accessible, and requires a valid access token.

## Reviewers

- [x] I have assigned the appropriate reviewer(s).

Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including subject-matter experts and editing/style reviewers.
