### PR TITLE
Convert API Body Parameters to `content`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Write Env
-        working-directory: typescript
         shell: pwsh
         run: |
           "ROSETTA_API_KEY=${{ secrets.ROSETTA_API_KEY }}" | Out-File -FilePath ./.env -Encoding utf8

--- a/python/orchestrate/_internal/api.py
+++ b/python/orchestrate/_internal/api.py
@@ -419,7 +419,7 @@ class OrchestrateApi(_RosettaApi):
 
     def convert_hl7_to_fhir_r4(
         self,
-        hl7_message: str,
+        content: str,
         patient_id: Optional[str] = None,
     ) -> ConvertHl7ToFhirR4Response:
         """
@@ -442,13 +442,13 @@ class OrchestrateApi(_RosettaApi):
         route = _get_id_dependent_route("/convert/v1/hl7tofhirr4", patient_id)
         return self._post(
             path=route,
-            body=hl7_message,
+            body=content,
             headers=headers,
         )
 
     def convert_cda_to_fhir_r4(
         self,
-        cda: str,
+        content: str,
         patient_id: Optional[str] = None,
     ) -> ConvertCdaToFhirR4Response:
         """
@@ -471,11 +471,11 @@ class OrchestrateApi(_RosettaApi):
         route = _get_id_dependent_route("/convert/v1/cdatofhirr4", patient_id)
         return self._post(
             path=route,
-            body=cda,
+            body=content,
             headers=headers,
         )
 
-    def convert_cda_to_pdf(self, cda: str) -> ConvertCdaToPdfResponse:
+    def convert_cda_to_pdf(self, content: str) -> ConvertCdaToPdfResponse:
         """
         Converts a CDA document into a PDF document
 
@@ -494,12 +494,12 @@ class OrchestrateApi(_RosettaApi):
         headers = {"Content-Type": "application/xml", "Accept": "application/pdf"}
         response = self._post(
             path="/convert/v1/cdatopdf",
-            body=cda,
+            body=content,
             headers=headers,
         )
         return response
 
-    def convert_fhir_r4_to_cda(self, fhir_bundle: Bundle) -> ConvertFhirR4ToCdaResponse:
+    def convert_fhir_r4_to_cda(self, content: Bundle) -> ConvertFhirR4ToCdaResponse:
         """
         Converts a FHIR R4 bundle into an aggregated CDA document.
 
@@ -518,13 +518,11 @@ class OrchestrateApi(_RosettaApi):
         headers = {"Accept": "application/xml"}
         return self._post(
             path="/convert/v1/fhirr4tocda",
-            body=fhir_bundle,
+            body=content,
             headers=headers,
         )
 
-    def convert_fhir_r4_to_omop(
-        self, fhir_bundle: Bundle
-    ) -> ConvertFhirR4ToOmopResponse:
+    def convert_fhir_r4_to_omop(self, content: Bundle) -> ConvertFhirR4ToOmopResponse:
         """
         Converts a FHIR R4 bundle into the OMOP Common Data Model v5.4 format.
 
@@ -545,14 +543,14 @@ class OrchestrateApi(_RosettaApi):
         }
         response = self._post(
             path="/convert/v1/fhirr4toomop",
-            body=fhir_bundle,
+            body=content,
             headers=headers,
         )
         return response
 
     def convert_x12_to_fhir_r4(
         self,
-        x12_document: str,
+        content: str,
         patient_id: Optional[str] = None,
     ) -> ConvertX12ToFhirR4Response:
         """
@@ -571,13 +569,13 @@ class OrchestrateApi(_RosettaApi):
         route = _get_id_dependent_route("/convert/v1/x12tofhirr4", patient_id)
         return self._post(
             path=route,
-            body=x12_document,
+            body=content,
             headers=headers,
         )
 
     def insight_risk_profile(
         self,
-        fhir_bundle: Bundle,
+        content: Bundle,
         hcc_version: Optional[Literal["22", "23", "24"]] = None,
         period_end_date: Optional[str] = None,
         ra_segment: Optional[
@@ -615,7 +613,7 @@ class OrchestrateApi(_RosettaApi):
         }
         return self._post(
             path="/insight/v1/riskprofile",
-            body=fhir_bundle,
+            body=content,
             parameters=parameters,
         )
 
@@ -898,7 +896,7 @@ class OrchestrateApi(_RosettaApi):
 
     def convert_combined_fhir_r4_bundles(
         self,
-        fhir_bundles: str,
+        content: str,
         person_id: Optional[str] = None,
     ) -> ConvertCombinedFhirR4BundlesResponse:
         """
@@ -921,6 +919,6 @@ class OrchestrateApi(_RosettaApi):
         route = _get_id_dependent_route("/convert/v1/combinefhirr4bundles", person_id)
         return self._post(
             path=route,
-            body=fhir_bundles,
+            body=content,
             headers=headers,
         )

--- a/python/orchestrate/convert.py
+++ b/python/orchestrate/convert.py
@@ -1,3 +1,4 @@
+import json
 from orchestrate._internal.fhir import Bundle
 
 ConvertHl7ToFhirR4Response = Bundle
@@ -11,3 +12,20 @@ ConvertFhirR4ToCdaResponse = str
 ConvertFhirR4ToOmopResponse = bytes
 
 ConvertX12ToFhirR4Response = Bundle
+
+
+def generate_convert_combined_fhir_bundles_request_from_bundles(
+    fhir_bundles: list[Bundle],
+) -> str:
+    """
+    Converts a list of FHIR bundles into a request body for the combine FHIR bundles endpoint.
+
+    ### Parameters
+
+    - `fhir_bundles`: (list[Bundle]): A list of FHIR bundles.
+
+    ### Returns
+
+    The content of the request for the combined FHIR bundles endpoint.
+    """
+    return "\n".join([json.dumps(bundle) for bundle in fhir_bundles])

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -186,7 +186,7 @@ ZPR||
 
 
 def test_api_convert_hl7_to_fhir_r4_without_patient_should_convert():
-    result = TEST_API.convert_hl7_to_fhir_r4(hl7_message=_HL7)
+    result = TEST_API.convert_hl7_to_fhir_r4(content=_HL7)
 
     assert result is not None
     assert result["resourceType"] == "Bundle"
@@ -194,7 +194,7 @@ def test_api_convert_hl7_to_fhir_r4_without_patient_should_convert():
 
 
 def test_api_convert_hl7_to_fhir_r4_with_patient_should_convert():
-    result = TEST_API.convert_hl7_to_fhir_r4(hl7_message=_HL7, patient_id="1234")
+    result = TEST_API.convert_hl7_to_fhir_r4(content=_HL7, patient_id="1234")
 
     assert result is not None
     assert result["resourceType"] == "Bundle"
@@ -284,7 +284,7 @@ _CDA = """
 
 
 def test_convert_cda_to_fhir_r4_without_patient_should_convert():
-    result = TEST_API.convert_cda_to_fhir_r4(cda=_CDA)
+    result = TEST_API.convert_cda_to_fhir_r4(content=_CDA)
 
     assert result is not None
     assert result["resourceType"] == "Bundle"
@@ -292,7 +292,7 @@ def test_convert_cda_to_fhir_r4_without_patient_should_convert():
 
 
 def test_convert_cda_to_fhir_r4_with_patient_should_convert():
-    result = TEST_API.convert_cda_to_fhir_r4(cda=_CDA, patient_id="1234")
+    result = TEST_API.convert_cda_to_fhir_r4(content=_CDA, patient_id="1234")
 
     assert result is not None
     assert result["resourceType"] == "Bundle"
@@ -308,7 +308,7 @@ def test_convert_cda_to_fhir_r4_with_patient_should_convert():
 
 
 def test_convert_cda_to_pdf_should_convert():
-    result = TEST_API.convert_cda_to_pdf(cda=_CDA)
+    result = TEST_API.convert_cda_to_pdf(content=_CDA)
 
     assert result is not None
     assert isinstance(result, bytes)
@@ -370,14 +370,14 @@ _BUNDLE = {
 
 
 def test_convert_fhir_r4_to_cda_should_convert():
-    result = TEST_API.convert_fhir_r4_to_cda(fhir_bundle=_BUNDLE)
+    result = TEST_API.convert_fhir_r4_to_cda(content=_BUNDLE)
 
     assert result is not None
     assert result.startswith("<?xml")
 
 
 def test_convert_fhir_r4_to_omop_should_convert():
-    result = TEST_API.convert_fhir_r4_to_omop(fhir_bundle=_BUNDLE)
+    result = TEST_API.convert_fhir_r4_to_omop(content=_BUNDLE)
 
     assert result is not None
     assert isinstance(result, bytes)
@@ -725,7 +725,7 @@ _RISK_PROFILE_BUNDLE = {
 
 def test_insight_risk_profile_should_return_bundle():
     result = TEST_API.insight_risk_profile(
-        fhir_bundle=_RISK_PROFILE_BUNDLE,
+        content=_RISK_PROFILE_BUNDLE,
         hcc_version="22",
         period_end_date="2020-12-31",
         ra_segment="community nondual aged",
@@ -744,7 +744,7 @@ def test_convert_combined_fhir_r4_bundles_should_combine():
         ]
     )
 
-    result = TEST_API.convert_combined_fhir_r4_bundles(fhir_bundles=bundles)
+    result = TEST_API.convert_combined_fhir_r4_bundles(content=bundles)
 
     assert result is not None
     assert result["resourceType"] == "Bundle"
@@ -760,7 +760,7 @@ def test_convert_combined_fhir_r4_bundles_with_person_should_combine():
     )
 
     result = TEST_API.convert_combined_fhir_r4_bundles(
-        fhir_bundles=bundles, person_id="1234"
+        content=bundles, person_id="1234"
     )
 
     assert result is not None
@@ -824,7 +824,7 @@ IEA*1*000000031~
 
 
 def test_convert_x12_to_fhir_r4_should_return_a_bundle():
-    result = TEST_API.convert_x12_to_fhir_r4(x12_document=_X12_DOCUMENT)
+    result = TEST_API.convert_x12_to_fhir_r4(content=_X12_DOCUMENT)
 
     assert result is not None
     assert result["resourceType"] == "Bundle"
@@ -832,9 +832,7 @@ def test_convert_x12_to_fhir_r4_should_return_a_bundle():
 
 
 def test_convert_x12_to_fhir_r4_with_patient_should_return_a_bundle():
-    result = TEST_API.convert_x12_to_fhir_r4(
-        x12_document=_X12_DOCUMENT, patient_id="1234"
-    )
+    result = TEST_API.convert_x12_to_fhir_r4(content=_X12_DOCUMENT, patient_id="1234")
 
     assert result is not None
     assert result["resourceType"] == "Bundle"

--- a/typescript/src/api.ts
+++ b/typescript/src/api.ts
@@ -347,7 +347,7 @@ export class OrchestrateApi {
     if (parameters.toString()) {
       route += `?${parameters.toString()}`;
     }
-    return this.rosettaApi.post(route, request.fhirBundle);
+    return this.rosettaApi.post(route, request.content);
   }
 
   /**
@@ -361,7 +361,7 @@ export class OrchestrateApi {
       "Content-Type": "text/plain",
     } as { [key: string]: string; };
     const route = this.getIDDependentRoute("/convert/v1/hl7tofhirr4", request.patientID);
-    return this.rosettaApi.post(route, request.hl7Message, headers);
+    return this.rosettaApi.post(route, request.content, headers);
   }
 
   /**
@@ -375,7 +375,7 @@ export class OrchestrateApi {
       "Content-Type": "application/xml",
     } as { [key: string]: string; };
     const route = this.getIDDependentRoute("/convert/v1/cdatofhirr4", request.patientID);
-    return this.rosettaApi.post(route, request.cda, headers);
+    return this.rosettaApi.post(route, request.content, headers);
   }
 
   /**
@@ -389,7 +389,7 @@ export class OrchestrateApi {
       "Content-Type": "application/xml",
       "Accept": "application/pdf",
     } as { [key: string]: string; };
-    return this.rosettaApi.post("/convert/v1/cdatopdf", request.cda, headers);
+    return this.rosettaApi.post("/convert/v1/cdatopdf", request.content, headers);
   }
 
   /**
@@ -402,7 +402,7 @@ export class OrchestrateApi {
     const headers = {
       "Accept": "application/xml",
     } as { [key: string]: string; };
-    return this.rosettaApi.post("/convert/v1/fhirr4tocda", request.fhirBundle, headers);
+    return this.rosettaApi.post("/convert/v1/fhirr4tocda", request.content, headers);
   }
 
   /**
@@ -414,7 +414,7 @@ export class OrchestrateApi {
     const headers = {
       "Accept": "application/zip",
     } as { [key: string]: string; };
-    return this.rosettaApi.post("/convert/v1/fhirr4toomop", request.fhirBundle, headers);
+    return this.rosettaApi.post("/convert/v1/fhirr4toomop", request.content, headers);
   }
 
   /**
@@ -428,7 +428,7 @@ export class OrchestrateApi {
       "Content-Type": "application/x-ndjson",
     } as { [key: string]: string; };
     const route = this.getIDDependentRoute("/convert/v1/combinefhirr4bundles", request.personID);
-    return this.rosettaApi.post(route, request.fhirBundles, headers);
+    return this.rosettaApi.post(route, request.content, headers);
   }
 
   /**
@@ -441,7 +441,7 @@ export class OrchestrateApi {
       "Content-Type": "text/plain",
     } as { [key: string]: string; };
     const route = this.getIDDependentRoute("/convert/v1/x12tofhirr4", request.patientID);
-    return this.rosettaApi.post(route, request.x12Document, headers);
+    return this.rosettaApi.post(route, request.content, headers);
   }
 
   private getIDDependentRoute(route: string, id?: string): string {

--- a/typescript/src/convert.ts
+++ b/typescript/src/convert.ts
@@ -1,15 +1,15 @@
 import { Bundle } from "fhir/r4";
 
 export type ConvertHl7ToFhirR4Request = {
+  content: string;
   patientID?: string;
-  hl7Message: string;
 };
 
 export type ConvertHl7ToFhirR4Response = Bundle;
 
 export type ConvertCdaToFhirR4Request = {
+  content: string;
   patientID?: string;
-  cda: string;
 };
 
 export type ConvertCdaToFhirR4Response = Bundle;
@@ -17,40 +17,40 @@ export type ConvertCdaToFhirR4Response = Bundle;
 export type ConvertCdaToFhirResponse = Bundle;
 
 export type ConvertCdaToPdfRequest = {
-  cda: string;
+  content: string;
 };
 
 export type ConvertCdaToPdfResponse = Buffer;
 
 export type ConvertFhirR4ToCdaRequest = {
-  fhirBundle: Bundle;
+  content: Bundle;
 };
 
 export type ConvertFhirR4ToCdaResponse = string;
 
 export type ConvertFhirR4ToOmopRequest = {
-  fhirBundle: Bundle;
+  content: Bundle;
 };
 
 export type ConvertFhirR4ToOmopResponse = Buffer;
 
 export type ConvertCombineFhirR4BundlesRequest = {
+  content: string;
   personID?: string;
-  fhirBundles: string;
 };
 
 export function generateConvertCombinedFhirBundlesRequestFromBundles(fhirBundles: Bundle[], personID?: string) {
   const bundles = fhirBundles.map((bundle) => JSON.stringify(bundle)).join("\n");
   return {
     personID: personID,
-    fhirBundles: bundles,
+    content: bundles,
   } as ConvertCombineFhirR4BundlesRequest;
 }
 
 export type ConvertCombineFhirR4BundlesResponse = Bundle;
 
 export type ConvertX12ToFhirR4Request = {
-  x12Document: string;
+  content: string;
   patientID?: string;
 };
 

--- a/typescript/src/insight.ts
+++ b/typescript/src/insight.ts
@@ -15,7 +15,7 @@ const hccVersions = [
 ] as const;
 
 export type InsightRiskProfileRequest = {
-  fhirBundle: Bundle;
+  content: Bundle;
   hccVersion?: typeof hccVersions[number];
   periodEndDate?: string;
   raSegment?: typeof raSegments[number];

--- a/typescript/tests/api.test.ts
+++ b/typescript/tests/api.test.ts
@@ -1,11 +1,13 @@
 import { Bundle } from 'fhir/r4';
 import { OrchestrateApi } from '../src/api';
 import { describe, it, expect } from '@jest/globals';
-import 'dotenv/config'
+import dotenv from 'dotenv';
 
+dotenv.config({ path: "../.env" });
 const apiKey = process.env.ROSETTA_API_KEY || "";
 const rosettaUrl = process.env.ROSETTA_BASE_URL || undefined;
 const additonalHeaders = process.env.ROSETTA_ADDITIONAL_HEADERS ? JSON.parse(process.env.ROSETTA_ADDITIONAL_HEADERS) : undefined;
+
 
 const orchestrate = new OrchestrateApi({
   apiKey: apiKey,
@@ -804,7 +806,7 @@ describe("standardize radiology", () => {
 describe("convert hl7 to fhir r4", () => {
   it("should convert hl7", async () => {
     const result = await orchestrate.convertHl7ToFhirR4({
-      hl7Message: hl7
+      content: hl7
     });
     expect(result).toBeDefined();
     expect(result.resourceType).toBe("Bundle");
@@ -813,7 +815,7 @@ describe("convert hl7 to fhir r4", () => {
 
   it("should convert hl7 with patient", async () => {
     const result = await orchestrate.convertHl7ToFhirR4({
-      hl7Message: hl7,
+      content: hl7,
       patientID: "1234"
     });
     expect(result).toBeDefined();
@@ -829,7 +831,7 @@ describe("convert hl7 to fhir r4", () => {
 describe("convert cda to fhir r4", () => {
   it("should convert cda", async () => {
     const result = await orchestrate.convertCdaToFhirR4({
-      cda: cda
+      content: cda
     });
     expect(result).toBeDefined();
     expect(result.resourceType).toBe("Bundle");
@@ -838,7 +840,7 @@ describe("convert cda to fhir r4", () => {
 
   it("should convert cda with patient", async () => {
     const result = await orchestrate.convertCdaToFhirR4({
-      cda: cda,
+      content: cda,
       patientID: "1234"
     });
     expect(result).toBeDefined();
@@ -854,7 +856,7 @@ describe("convert cda to fhir r4", () => {
 describe("convert cda to pdf", () => {
   it("should convert cda", async () => {
     const result = await orchestrate.convertCdaToPdf({
-      cda: cda
+      content: cda
     });
     expect(result).toBeDefined();
     const resultIntegers = new Int8Array(result);
@@ -866,7 +868,7 @@ describe("convert cda to pdf", () => {
 describe("convert fhir r4 to cda", () => {
   it("should convert fhir", async () => {
     const result = await orchestrate.convertFhirR4ToCda({
-      fhirBundle: fhir
+      content: fhir
     });
     expect(result).toBeDefined();
     expect(result).toContain("<?xml");
@@ -876,7 +878,7 @@ describe("convert fhir r4 to cda", () => {
 describe("convert fhir r4 to omop", () => {
   it("should convert fhir", async () => {
     const result = await orchestrate.convertFhirR4ToOmop({
-      fhirBundle: fhir
+      content: fhir
     });
     expect(result).toBeDefined();
     const resultIntegers = new Int8Array(result);
@@ -888,7 +890,7 @@ describe("convert fhir r4 to omop", () => {
 describe("convert x12 to fhir r4", () => {
   it("should convert x12", async () => {
     const result = await orchestrate.convertX12ToFhirR4({
-      x12Document: x12Document
+      content: x12Document
     });
     expect(result).toBeDefined();
     expect(result.resourceType).toBe("Bundle");
@@ -897,7 +899,7 @@ describe("convert x12 to fhir r4", () => {
 
   it("should convert x12 with patient", async () => {
     const result = await orchestrate.convertX12ToFhirR4({
-      x12Document: x12Document,
+      content: x12Document,
       patientID: "1234"
     });
     expect(result).toBeDefined();
@@ -915,7 +917,7 @@ describe("insight risk profile", () => {
       hccVersion: "22",
       periodEndDate: "2020-12-31",
       raSegment: "community nondual aged",
-      fhirBundle: riskProfileBundle,
+      content: riskProfileBundle,
     });
     expect(result).toBeDefined();
     expect(result.resourceType).toBe("Bundle");
@@ -1050,7 +1052,6 @@ describe("get fhir r4 value set by scope", () => {
       pageNumber: 1,
       pageSize: 2
     });
-    console.log(result.entry?.[0].resource);
     expect(result).toBeDefined();
     expect(result.resourceType).toBe("Bundle");
     expect(result.total).toBeGreaterThan(0);
@@ -1129,7 +1130,7 @@ ${JSON.stringify(fhir)}
 `);
 
     const result = await orchestrate.convertCombinedFhirR4Bundles({
-      fhirBundles: bundles
+      content: bundles
     });
 
     expect(result).toBeDefined();
@@ -1144,7 +1145,7 @@ ${JSON.stringify(fhir)}
 `);
 
     const result = await orchestrate.convertCombinedFhirR4Bundles({
-      fhirBundles: bundles,
+      content: bundles,
       personID: "1234"
     });
 


### PR DESCRIPTION
## Description of Changes

The current version uses method-aware parameter names for Convert operations' POST data. This PR removes the method-aware parameter names and replaces them with a single parameter name, `content`, for all POST data outside of `application/json`.

The following methods are affected:

- Convert HL7 to FHIR R4
- Convert CDA to FHIR R4
- Convert CDA to PDF
- Convert FHIR R4 to CDA
- Convert FHIR R4 to OMOP
- Insight Risk Profile
- Convert combined FHIR R4 bundles
- Convert X12 to FHIR R4

I've also included a Python version of `convert.generate_convert_combined_fhir_bundles_request_from_bundles`, which was previously only available in TypeScript.

## Security

**REMINDER: All file contents are public.**

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note: No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] My changes do not introduce any security risks, or any such risks have been properly mitigated.

No changes have been made to data processing or storage. The only changes are to the names of the method parameters.

## Reviewers

- [x] I have assigned the appropriate reviewer(s).
