### PR TITLE
Batch Operations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,38 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "/python"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 4
     assignees:
       - "jeremytwfortune"
+    groups:
+      minor-patch:
+        patterns: "*"
+        update_types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "npm"
+    directory: "/typescript"
+    schedule:
+      interval: weekly
+    assignees:
+      - "jeremytwfortune"
+    groups:
+      minor-patch:
+        patterns: "*"
+        update_types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 4
     assignees:
       - "jeremytwfortune"
+    groups:
+      minor-patch:
+        patterns: "*"
+        update_types:
+          - "minor"
+          - "patch"

--- a/python/orchestrate/terminology.py
+++ b/python/orchestrate/terminology.py
@@ -1,4 +1,4 @@
-from typing import Literal, TypedDict
+from typing import Literal, Optional, TypedDict
 
 from orchestrate._internal.fhir import (
     Bundle,
@@ -27,6 +27,12 @@ Covid19Condition = Literal[
     "SignsAndSymptoms",
     "NonspecificRespiratoryViralInfection",
 ]
+
+
+class ClassifyConditionRequest(TypedDict):
+    code: str
+    system: ClassifyConditionSystems
+    display: Optional[str]
 
 
 class ClassifyConditionResponse(TypedDict):
@@ -60,6 +66,12 @@ Covid19Rx = Literal[
 ]
 
 
+class ClassifyMedicationRequest(TypedDict):
+    code: str
+    system: ClassifyMedicationSystems
+    display: Optional[str]
+
+
 class ClassifyMedicationResponse(TypedDict):
     medRtTherapeuticClass: list[str]
     rxNormIngredient: list[str]
@@ -74,6 +86,12 @@ ClassifyObservationSystems = Literal[
     "http://snomed.info/sct",
     "SNOMED",
 ]
+
+
+class ClassifyObservationRequest(TypedDict):
+    code: str
+    system: ClassifyObservationSystems
+    display: Optional[str]
 
 
 class ClassifyObservationResponse(TypedDict):
@@ -120,6 +138,13 @@ StandardizeTargetSystems = Literal[
     "http://hl7.org/fhir/sid/ndc",
     "http://hl7.org/fhir/sid/cvx",
 ]
+
+
+class StandardizeRequest(TypedDict):
+    code: Optional[str]
+    system: Optional[StandardizeTargetSystems]
+    display: Optional[str]
+
 
 StandardizeResponseSystems = Literal[
     "http://hl7.org/fhir/sid/icd-10",

--- a/python/orchestrate/terminology.py
+++ b/python/orchestrate/terminology.py
@@ -1,4 +1,9 @@
-from typing import Literal, Optional, TypedDict
+import sys
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Literal, TypedDict, NotRequired
+else:
+    from typing import Literal, TypedDict, NotRequired
 
 from orchestrate._internal.fhir import (
     Bundle,
@@ -32,7 +37,7 @@ Covid19Condition = Literal[
 class ClassifyConditionRequest(TypedDict):
     code: str
     system: ClassifyConditionSystems
-    display: Optional[str]
+    display: NotRequired[str]
 
 
 class ClassifyConditionResponse(TypedDict):
@@ -69,7 +74,7 @@ Covid19Rx = Literal[
 class ClassifyMedicationRequest(TypedDict):
     code: str
     system: ClassifyMedicationSystems
-    display: Optional[str]
+    display: NotRequired[str]
 
 
 class ClassifyMedicationResponse(TypedDict):
@@ -91,7 +96,7 @@ ClassifyObservationSystems = Literal[
 class ClassifyObservationRequest(TypedDict):
     code: str
     system: ClassifyObservationSystems
-    display: Optional[str]
+    display: NotRequired[str]
 
 
 class ClassifyObservationResponse(TypedDict):
@@ -141,9 +146,9 @@ StandardizeTargetSystems = Literal[
 
 
 class StandardizeRequest(TypedDict):
-    code: Optional[str]
-    system: Optional[StandardizeTargetSystems]
-    display: Optional[str]
+    code: NotRequired[str]
+    system: NotRequired[StandardizeTargetSystems]
+    display: NotRequired[str]
 
 
 StandardizeResponseSystems = Literal[

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -9,6 +9,12 @@ from dotenv import load_dotenv
 from orchestrate import OrchestrateApi
 from requests import HTTPError
 
+from orchestrate.terminology import (
+    ClassifyMedicationRequest,
+    ClassifyObservationRequest,
+    StandardizeRequest,
+)
+
 
 def setup_test_api():
     load_dotenv(Path(__file__).parent.parent.parent / ".env", override=True)
@@ -103,18 +109,6 @@ def test_api_classify_condition_should_classify(condition):
             {"request": {"code": "2468231", "system": "RxNorm"}},
             id="request-name",
         ),
-        pytest.param(
-            {
-                "request": [
-                    {
-                        "code": "2468231",
-                        "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-                    },
-                    {"code": "2468231", "system": "RxNorm"},
-                ]
-            },
-            id="batch",
-        ),
     ],
 )
 def test_api_classify_medication_should_classify(medication):
@@ -126,11 +120,25 @@ def test_api_classify_medication_should_classify(medication):
     response = kwarg_response
     assert kwarg_response == positional_response
     assert response is not None
-    if isinstance(response, list):
-        assert len(response) == 2
-        assert [item["rxNormGeneric"] for item in response]
-    else:
-        assert response["rxNormGeneric"]
+    assert response["rxNormGeneric"]
+
+
+def test_api_classify_medication_should_classify_batch() -> None:
+    request: list[ClassifyMedicationRequest] = [
+        {
+            "code": "2468231",
+            "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+        },
+        {"code": "2468231", "system": "RxNorm"},
+    ]
+
+    response = TEST_API.classify_medication(request=request)
+    positional_response = TEST_API.classify_medication(request)
+
+    assert response == positional_response
+    assert response is not None
+    assert len(response) == 2
+    assert [item["rxNormGeneric"] for item in response]
 
 
 @pytest.mark.parametrize(
@@ -157,18 +165,6 @@ def test_api_classify_medication_should_classify(medication):
             {"request": {"code": "94558-4", "system": "LOINC"}},
             id="request-name",
         ),
-        pytest.param(
-            {
-                "request": [
-                    {
-                        "code": "94558-4",
-                        "system": "http://loinc.org",
-                    },
-                    {"code": "94558-4", "system": "LOINC"},
-                ]
-            },
-            id="batch",
-        ),
     ],
 )
 def test_api_classify_observation_should_classify(observation):
@@ -180,11 +176,26 @@ def test_api_classify_observation_should_classify(observation):
     response = kwarg_response
     assert kwarg_response == positional_response
     assert response is not None
-    if isinstance(response, list):
-        assert len(response) == 2
-        assert [item["loincClass"] == "MICRO" for item in response]
-    else:
-        assert response["loincClass"] == "MICRO"
+    assert response["loincClass"] == "MICRO"
+
+
+def test_api_classify_observation_should_classify_batch() -> None:
+    requests: list[ClassifyObservationRequest] = [
+        {
+            "code": "94558-4",
+            "system": "http://loinc.org",
+        },
+        {"code": "94558-4", "system": "LOINC"},
+    ]
+
+    kwarg_response = TEST_API.classify_observation(request=requests)
+    positional_response = TEST_API.classify_observation(requests)
+
+    response = kwarg_response
+    assert kwarg_response == positional_response
+    assert response is not None
+    assert len(response) == 2
+    assert [item["loincClass"] == "MICRO" for item in response]
 
 
 _STANDARDIZE_CONDITION_PAYLOADS = [
@@ -194,17 +205,6 @@ _STANDARDIZE_CONDITION_PAYLOADS = [
     pytest.param({"request": {"code": "J45.50"}}, "J45.50", id="icd-request"),
     pytest.param({"display": "dm2"}, "44054006", id="display"),
     pytest.param({"request": {"display": "dm2"}}, "44054006", id="display-request"),
-    pytest.param(
-        {
-            "request": [
-                {"code": "370221004"},
-                {"code": "J45.50"},
-                {"display": "dm2"},
-            ]
-        },
-        ["370221004", "J45.50", "44054006"],
-        id="batch",
-    ),
 ]
 
 
@@ -217,13 +217,25 @@ def test_api_standardize_condition_should_standardize(payload, expected):
 
     assert response == positional_response
     assert response is not None
-    if isinstance(response, list):
-        assert len(response) == 3
-        assert any(coding["code"] == expected[0] for coding in response[0]["coding"])
-        assert any(coding["code"] == expected[1] for coding in response[1]["coding"])
-        assert any(coding["code"] == expected[2] for coding in response[2]["coding"])
-    else:
-        assert any(coding["code"] == expected for coding in response["coding"])
+    assert any(coding["code"] == expected for coding in response["coding"])
+
+
+def test_api_standardize_condition_should_standardize_batch() -> None:
+    requests: list[StandardizeRequest] = [
+        {"code": "370221004"},
+        {"code": "J45.50"},
+        {"display": "dm2"},
+    ]
+    expected = ["370221004", "J45.50", "44054006"]
+    response = TEST_API.standardize_condition(request=requests)
+    positional_response = TEST_API.standardize_condition(requests)
+
+    assert response == positional_response
+    assert response is not None
+    assert len(response) == 3
+    assert any(coding["code"] == expected[0] for coding in response[0]["coding"])
+    assert any(coding["code"] == expected[1] for coding in response[1]["coding"])
+    assert any(coding["code"] == expected[2] for coding in response[2]["coding"])
 
 
 _STANDARDIZE_LAB_PAYLOADS = [
@@ -237,16 +249,6 @@ _STANDARDIZE_LAB_PAYLOADS = [
         "43396009",
         id="display-request",
     ),
-    pytest.param(
-        {
-            "request": [
-                {"code": "4548-4"},
-                {"display": "hba1c 1/15/22 from outside lab"},
-            ]
-        },
-        ["4548-4", "43396009"],
-        id="batch",
-    ),
 ]
 
 
@@ -257,12 +259,24 @@ def test_api_standardize_lab_should_standardize(payload, expected):
 
     assert response == positional_response
     assert response is not None
-    if isinstance(response, list):
-        assert len(response) == 2
-        assert any(coding["code"] == expected[0] for coding in response[0]["coding"])
-        assert any(coding["code"] == expected[1] for coding in response[1]["coding"])
-    else:
-        assert any(coding["code"] == expected for coding in response["coding"])
+    assert any(coding["code"] == expected for coding in response["coding"])
+
+
+def test_api_standardize_lab_should_standardize_batch() -> None:
+    requests: list[StandardizeRequest] = [
+        {"code": "4548-4"},
+        {"display": "hba1c 1/15/22 from outside lab"},
+    ]
+    expected = ["4548-4", "43396009"]
+
+    response = TEST_API.standardize_lab(request=requests)
+    positional_response = TEST_API.standardize_lab(requests)
+
+    assert response == positional_response
+    assert response is not None
+    assert len(response) == 2
+    assert any(coding["code"] == expected[0] for coding in response[0]["coding"])
+    assert any(coding["code"] == expected[1] for coding in response[1]["coding"])
 
 
 _STANDARDIZE_MEDICATION_PAYOADS = [
@@ -290,19 +304,6 @@ _STANDARDIZE_MEDICATION_PAYOADS = [
         "1796093",
         id="display-request",
     ),
-    pytest.param(
-        {
-            "request": [
-                {"code": "861004", "system": "RxNorm"},
-                {"code": "59267-1000-02"},
-                {
-                    "display": "Jentadueto extended (linagliptin 2.5 / metFORMIN  1000mg)"
-                },
-            ]
-        },
-        ["861004", "59267100002", "1796093"],
-        id="batch",
-    ),
 ]
 
 
@@ -315,13 +316,26 @@ def test_api_standardize_medication_should_standardize(payload, expected):
 
     assert response == positional_response
     assert response is not None
-    if isinstance(response, list):
-        assert len(response) == 3
-        assert any(coding["code"] == expected[0] for coding in response[0]["coding"])
-        assert any(coding["code"] == expected[1] for coding in response[1]["coding"])
-        assert any(coding["code"] == expected[2] for coding in response[2]["coding"])
-    else:
-        assert any(coding["code"] == expected for coding in response["coding"])
+    assert any(coding["code"] == expected for coding in response["coding"])
+
+
+def test_api_standardize_medication_should_standardize_batch() -> None:
+    requests: list[StandardizeRequest] = [
+        {"code": "861004", "system": "RxNorm"},
+        {"code": "59267-1000-02"},
+        {"display": "Jentadueto extended (linagliptin 2.5 / metFORMIN  1000mg)"},
+    ]
+    expected = ["861004", "59267100002", "1796093"]
+
+    response = TEST_API.standardize_medication(request=requests)
+    positional_response = TEST_API.standardize_medication(requests)
+
+    assert response == positional_response
+    assert response is not None
+    assert len(response) == 3
+    assert any(coding["code"] == expected[0] for coding in response[0]["coding"])
+    assert any(coding["code"] == expected[1] for coding in response[1]["coding"])
+    assert any(coding["code"] == expected[2] for coding in response[2]["coding"])
 
 
 _STANDARDIZE_OBSERVATION_PAYLOADS = [
@@ -329,12 +343,6 @@ _STANDARDIZE_OBSERVATION_PAYLOADS = [
     pytest.param({"request": {"code": "8480-6"}}, "8480-6", id="loinc-request"),
     pytest.param({"display": "BMI"}, "39156-5", id="display"),
     pytest.param({"request": {"display": "BMI"}}, "39156-5", id="display-request"),
-    pytest.param(
-        {"request": [{"code": "8480-6"}, {"display": "BMI"}]},
-        ["8480-6", "39156-5"],
-        id="batch",
-        marks=pytest.mark.xfail(reason="Batch requests not supported"),
-    ),
 ]
 
 
@@ -347,12 +355,21 @@ def test_api_standardize_observation_should_standardize(payload, expected):
 
     assert response == positional_response
     assert response is not None
-    if isinstance(response, list):
-        assert len(response) == 2
-        assert any(coding["code"] == expected[0] for coding in response[0]["coding"])
-        assert any(coding["code"] == expected[1] for coding in response[1]["coding"])
-    else:
-        assert any(coding["code"] == expected for coding in response["coding"])
+    assert any(coding["code"] == expected for coding in response["coding"])
+
+
+def test_api_standardize_observation_should_standardize_batch() -> None:
+    requests: list[StandardizeRequest] = [{"code": "8480-6"}, {"display": "BMI"}]
+    expected = ["8480-6", "39156-5"]
+
+    response = TEST_API.standardize_observation(request=requests)
+    positional_response = TEST_API.standardize_observation(requests)
+
+    assert response == positional_response
+    assert response is not None
+    assert len(response) == 2
+    assert any(coding["code"] == expected[0] for coding in response[0]["coding"])
+    assert any(coding["code"] == expected[1] for coding in response[1]["coding"])
 
 
 _STANDARDIZE_PROCEDURE_PAYLOADS = [
@@ -360,12 +377,6 @@ _STANDARDIZE_PROCEDURE_PAYLOADS = [
     pytest.param({"request": {"code": "80146002"}}, "80146002", id="snomed-request"),
     pytest.param({"display": "ct head&neck"}, "429858000", id="display"),
     pytest.param({"request": {"display": "ct head&neck"}}, "429858000", id="display"),
-    pytest.param(
-        {"request": [{"code": "80146002"}, {"display": "ct head&neck"}]},
-        ["80146002", "429858000"],
-        id="batch",
-        marks=pytest.mark.xfail(reason="Batch requests not supported"),
-    ),
 ]
 
 
@@ -378,12 +389,24 @@ def test_api_standardize_procedure_should_standardize(payload, expected):
 
     assert response == positional_response
     assert response is not None
-    if isinstance(response, list):
-        assert len(response) == 2
-        assert any(coding["code"] == expected[0] for coding in response[0]["coding"])
-        assert any(coding["code"] == expected[1] for coding in response[1]["coding"])
-    else:
-        assert any(coding["code"] == expected for coding in response["coding"])
+    assert any(coding["code"] == expected for coding in response["coding"])
+
+
+def test_api_standardize_procedure_should_standardize_batch() -> None:
+    requests: list[StandardizeRequest] = [
+        {"code": "80146002"},
+        {"display": "ct head&neck"},
+    ]
+    expected = ["80146002", "429858000"]
+
+    response = TEST_API.standardize_procedure(request=requests)
+    positional_response = TEST_API.standardize_procedure(requests)
+
+    assert response == positional_response
+    assert response is not None
+    assert len(response) == 2
+    assert any(coding["code"] == expected[0] for coding in response[0]["coding"])
+    assert any(coding["code"] == expected[1] for coding in response[1]["coding"])
 
 
 _STANDARDIZE_RADIOLOGY_PAYLOADS = [
@@ -403,16 +426,6 @@ _STANDARDIZE_RADIOLOGY_PAYLOADS = [
         "30799-1",
         id="display-request",
     ),
-    pytest.param(
-        {
-            "request": [
-                {"code": "711232001", "system": "SNOMED"},
-                {"display": "CT scan of head w/o iv contrast 3d ago@StJoes"},
-            ]
-        },
-        ["711232001", "30799-1"],
-        id="batch",
-    ),
 ]
 
 
@@ -425,12 +438,24 @@ def test_api_standardize_radiology_should_standardize(payload, expected):
 
     assert response == positional_response
     assert response is not None
-    if isinstance(response, list):
-        assert len(response) == 2
-        assert any(coding["code"] == expected[0] for coding in response[0]["coding"])
-        assert any(coding["code"] == expected[1] for coding in response[1]["coding"])
-    else:
-        assert any(coding["code"] == expected for coding in response["coding"])
+    assert any(coding["code"] == expected for coding in response["coding"])
+
+
+def test_api_standardize_radiology_should_standardize_batch() -> None:
+    requests: list[StandardizeRequest] = [
+        {"code": "711232001", "system": "SNOMED"},
+        {"display": "CT scan of head w/o iv contrast 3d ago@StJoes"},
+    ]
+    expected = ["711232001", "30799-1"]
+
+    response = TEST_API.standardize_radiology(request=requests)
+    positional_response = TEST_API.standardize_radiology(requests)
+
+    assert response == positional_response
+    assert response is not None
+    assert len(response) == 2
+    assert any(coding["code"] == expected[0] for coding in response[0]["coding"])
+    assert any(coding["code"] == expected[1] for coding in response[1]["coding"])
 
 
 _HL7 = """

--- a/typescript/src/api.ts
+++ b/typescript/src/api.ts
@@ -55,6 +55,10 @@ export interface Configuration {
   additionalHeaders?: { [key: string]: string; };
 }
 
+type BatchResponse<T> = {
+  items: T;
+};
+
 export class OrchestrateApi {
   rosettaApi: RosettaApi;
 
@@ -77,6 +81,14 @@ export class OrchestrateApi {
     );
   }
 
+  async handleBatchOverload<TIn, TOut>(url: string, request: TIn): Promise<TOut> {
+    if (Array.isArray(request)) {
+      const batchResponse = await this.rosettaApi.post(`${url}/batch`, { items: request });
+      return (batchResponse as BatchResponse<TOut>).items;
+    }
+    return this.rosettaApi.post(url, request);
+  }
+
   /**
    * Classifies a condition, problem, or diagnosis. The input must be from one of the following code systems:
    *
@@ -86,9 +98,20 @@ export class OrchestrateApi {
    * @param request A FHIR Coding
    * @returns A set of key/value pairs representing different classification of the supplied coding
    * @link https://rosetta-api.docs.careevolution.com/terminology/classify/condition.html
+  */
+  classifyCondition(request: ClassifyConditionRequest): Promise<ClassifyConditionResponse>;
+  /**
+   * Classifies conditions, problems, or diagnoses. The input must be from one of the following code systems:
+   * - ICD-10-CM
+   * - ICD-9-CM-Diagnosis
+   * - SNOMED
+   * @param request An array of FHIR Codings
+   * @returns An array of sets of key/value pairs representing different classification of the supplied coding in the same order as the input
+   * @link https://rosetta-api.docs.careevolution.com/terminology/classify/condition.html
    */
-  classifyCondition(request: ClassifyConditionRequest): Promise<ClassifyConditionResponse> {
-    return this.rosettaApi.post("/terminology/v1/classify/condition", request);
+  classifyCondition(request: ClassifyConditionRequest[]): Promise<ClassifyConditionResponse[]>;
+  classifyCondition(request: ClassifyConditionRequest | ClassifyConditionRequest[]): Promise<ClassifyConditionResponse | ClassifyConditionResponse[]> {
+    return this.handleBatchOverload("/terminology/v1/classify/condition", request);
   }
 
   /**
@@ -102,8 +125,21 @@ export class OrchestrateApi {
    * @returns A set of key/value pairs representing different classification of the supplied coding
    * @link https://rosetta-api.docs.careevolution.com/terminology/classify/medication.html
    */
-  classifyMedication(request: ClassifyMedicationRequest): Promise<ClassifyMedicationResponse> {
-    return this.rosettaApi.post("/terminology/v1/classify/medication", request);
+  classifyMedication(request: ClassifyMedicationRequest): Promise<ClassifyMedicationResponse>;
+  /**
+   * Classifies medications. The input must be from one of the following code systems:
+   *
+   * - RxNorm
+   * - NDC
+   * - CVX
+   * - SNOMED
+   * @param request An array of FHIR Codings
+   * @returns An array of sets of key/value pairs representing different classification of the supplied coding in the same order as the input
+   * @link https://rosetta-api.docs.careevolution.com/terminology/classify/medication.html
+   */
+  classifyMedication(request: ClassifyMedicationRequest[]): Promise<ClassifyMedicationResponse[]>;
+  classifyMedication(request: ClassifyMedicationRequest | ClassifyMedicationRequest[]): Promise<ClassifyMedicationResponse | ClassifyMedicationResponse[]> {
+    return this.handleBatchOverload("/terminology/v1/classify/medication", request);
   }
 
   /**
@@ -115,8 +151,19 @@ export class OrchestrateApi {
    * @returns A set of key/value pairs representing different classification of the supplied coding
    * @link https://rosetta-api.docs.careevolution.com/terminology/classify/observation.html
    */
-  classifyObservation(request: ClassifyObservationRequest): Promise<ClassifyObservationResponse> {
-    return this.rosettaApi.post("/terminology/v1/classify/observation", request);
+  classifyObservation(request: ClassifyObservationRequest): Promise<ClassifyObservationResponse>;
+  /**
+   * Classifies observations, including lab observations and panels, radiology or other reports. The input must be from one of the following code systems:
+   *
+   * - LOINC
+   * - SNOMED
+   * @param request An array of FHIR Codings
+   * @returns An array of sets of key/value pairs representing different classification of the supplied coding in the same order as the input
+   * @link https://rosetta-api.docs.careevolution.com/terminology/classify/observation.html
+   */
+  classifyObservation(request: ClassifyObservationRequest[]): Promise<ClassifyObservationResponse[]>;
+  classifyObservation(request: ClassifyObservationRequest | ClassifyObservationRequest[]): Promise<ClassifyObservationResponse | ClassifyObservationResponse[]> {
+    return this.handleBatchOverload("/terminology/v1/classify/observation", request);
   }
 
   /**
@@ -125,8 +172,16 @@ export class OrchestrateApi {
    * @returns A collection of standardized codes
    * @link https://rosetta-api.docs.careevolution.com/terminology/standardize/condition.html
    */
-  standardizeCondition(request: StandardizeRequest): Promise<StandardizeConditionResponse> {
-    return this.rosettaApi.post("/terminology/v1/standardize/condition", request);
+  standardizeCondition(request: StandardizeRequest): Promise<StandardizeConditionResponse>;
+  /**
+   * Standardize conditions, problems, or diagnoses
+   * @param request An array of FHIR Codings
+   * @returns An array of collections of standardized codes in the same order as the input
+   * @link https://rosetta-api.docs.careevolution.com/terminology/standardize/condition.html
+   */
+  standardizeCondition(request: StandardizeRequest[]): Promise<StandardizeConditionResponse[]>;
+  standardizeCondition(request: StandardizeRequest | StandardizeRequest[]): Promise<StandardizeConditionResponse | StandardizeConditionResponse[]> {
+    return this.handleBatchOverload("/terminology/v1/standardize/condition", request);
   }
 
   /**
@@ -135,8 +190,16 @@ export class OrchestrateApi {
    * @returns A collection of standardized codes
    * @link https://rosetta-api.docs.careevolution.com/terminology/standardize/medication.html
    */
-  standardizeMedication(request: StandardizeRequest): Promise<StandardizeMedicationResponse> {
-    return this.rosettaApi.post("/terminology/v1/standardize/medication", request);
+  standardizeMedication(request: StandardizeRequest): Promise<StandardizeMedicationResponse>;
+  /**
+   * Standardize medication codes
+   * @param request An array of FHIR Codings
+   * @returns An array of collections of standardized codes in the same order as the input
+   * @link https://rosetta-api.docs.careevolution.com/terminology/standardize/medication.html
+   */
+  standardizeMedication(request: StandardizeRequest[]): Promise<StandardizeMedicationResponse[]>;
+  standardizeMedication(request: StandardizeRequest | StandardizeRequest[]): Promise<StandardizeMedicationResponse | StandardizeMedicationResponse[]> {
+    return this.handleBatchOverload("/terminology/v1/standardize/medication", request);
   }
 
   /**
@@ -145,8 +208,16 @@ export class OrchestrateApi {
    * @returns A collection of standardized codes
    * @link https://rosetta-api.docs.careevolution.com/terminology/standardize/observation.html
    */
-  standardizeObservation(request: StandardizeRequest): Promise<StandardizeObservationResponse> {
-    return this.rosettaApi.post("/terminology/v1/standardize/observation", request);
+  standardizeObservation(request: StandardizeRequest): Promise<StandardizeObservationResponse>;
+  /**
+   * Standardize observation codes
+   * @param request An array of FHIR Codings
+   * @returns An array of collections of standardized codes in the same order as the input
+   * @link https://rosetta-api.docs.careevolution.com/terminology/standardize/observation.html
+   */
+  standardizeObservation(request: StandardizeRequest[]): Promise<StandardizeObservationResponse[]>;
+  standardizeObservation(request: StandardizeRequest | StandardizeRequest[]): Promise<StandardizeObservationResponse | StandardizeObservationResponse[]> {
+    return this.handleBatchOverload("/terminology/v1/standardize/observation", request);
   }
 
   /**
@@ -155,8 +226,16 @@ export class OrchestrateApi {
    * @returns A collection of standardized codes
    * @link https://rosetta-api.docs.careevolution.com/terminology/standardize/procedure.html
    */
-  standardizeProcedure(request: StandardizeRequest): Promise<StandardizeObservationResponse> {
-    return this.rosettaApi.post("/terminology/v1/standardize/procedure", request);
+  standardizeProcedure(request: StandardizeRequest): Promise<StandardizeObservationResponse>;
+  /**
+   * Standardize procedures
+   * @param request An array of FHIR Codings
+   * @returns An array of collections of standardized codes in the same order as the input
+   * @link https://rosetta-api.docs.careevolution.com/terminology/standardize/procedure.html
+   */
+  standardizeProcedure(request: StandardizeRequest[]): Promise<StandardizeObservationResponse[]>;
+  standardizeProcedure(request: StandardizeRequest | StandardizeRequest[]): Promise<StandardizeObservationResponse | StandardizeObservationResponse[]> {
+    return this.handleBatchOverload("/terminology/v1/standardize/procedure", request);
   }
 
   /**
@@ -165,8 +244,16 @@ export class OrchestrateApi {
    * @returns A collection of standardized codes
    * @link https://rosetta-api.docs.careevolution.com/terminology/standardize/lab.html
    */
-  standardizeLab(request: StandardizeRequest): Promise<StandardizeLabResponse> {
-    return this.rosettaApi.post("/terminology/v1/standardize/lab", request);
+  standardizeLab(request: StandardizeRequest): Promise<StandardizeLabResponse>;
+  /**
+   * Standardize lab observations or report codes
+   * @param request An array of FHIR Codings
+   * @returns An array of collections of standardized codes in the same order as the input
+   * @link https://rosetta-api.docs.careevolution.com/terminology/standardize/lab.html
+   */
+  standardizeLab(request: StandardizeRequest[]): Promise<StandardizeLabResponse[]>;
+  standardizeLab(request: StandardizeRequest | StandardizeRequest[]): Promise<StandardizeLabResponse | StandardizeLabResponse[]> {
+    return this.handleBatchOverload("/terminology/v1/standardize/lab", request);
   }
 
   /**
@@ -175,8 +262,16 @@ export class OrchestrateApi {
    * @returns A collection of standardized codes
    * @link https://rosetta-api.docs.careevolution.com/terminology/standardize/radiology.html
    */
-  standardizeRadiology(request: StandardizeRequest): Promise<StandardizeRadiologyResponse> {
-    return this.rosettaApi.post("/terminology/v1/standardize/radiology", request);
+  standardizeRadiology(request: StandardizeRequest): Promise<StandardizeRadiologyResponse>;
+  /**
+   * Standardize radiology or other report codes
+   * @param request An array of FHIR Codings
+   * @returns An array of collections of standardized codes in the same order as the input
+   * @link https://rosetta-api.docs.careevolution.com/terminology/standardize/radiology.html
+   */
+  standardizeRadiology(request: StandardizeRequest[]): Promise<StandardizeRadiologyResponse[]>;
+  standardizeRadiology(request: StandardizeRequest | StandardizeRequest[]): Promise<StandardizeRadiologyResponse | StandardizeRadiologyResponse[]> {
+    return this.handleBatchOverload("/terminology/v1/standardize/radiology", request);
   }
 
   /**


### PR DESCRIPTION
## Description of Changes

This PR adds support for executing the `/batch` endpoints of Classify and Standardize. No new methods are added, rather the existing methods are updated to support batch requests as long as lists (Python) or arrays (TypeScript) as passed instead of the single request.

For Python, this also means overloading the methods to support a single-object request object in the same style as the TypeScript methods. This is a little against the grain for Python libraries, but it makes the extension from single requests to batch requests more natural.

## Security

**REMINDER: All file contents are public.**

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note: No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] My changes do not introduce any security risks, or any such risks have been properly mitigated.

This extends the current functionality by also hitting the `/batch` endpoints. No authentication or authorization changes are made, only the structure of the requests passed to these new routes.

## Reviewers

- [x] I have assigned the appropriate reviewer(s).
