### PR TITLE
Scope -> Extension.Scope

### DIFF
--- a/python/orchestrate/_internal/api.py
+++ b/python/orchestrate/_internal/api.py
@@ -733,7 +733,7 @@ class OrchestrateApi(_RosettaApi):
         <https://rosetta-api.docs.careevolution.com/fhir/valueset.html>
         """
         parameters = {
-            "scope": scope,
+            "extension.scope": scope,
             "_summary": "true",
         }
         return self._get(
@@ -832,7 +832,7 @@ class OrchestrateApi(_RosettaApi):
         parameters = {
             **_get_pagination_parameters(page_number, page_size),
             "name": name,
-            "scope": scope,
+            "extension.scope": scope,
         }
         return self._get(
             path=f"/terminology/v1/fhir/r4/valueset",

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -920,6 +920,7 @@ def test_summarize_fhir_r4_value_set_scope_should_return_bundle():
     assert result is not None
     assert result["resourceType"] == "Bundle"
     assert len(result["entry"]) > 0
+    assert len(result["entry"]) < 10000
 
 
 def test_get_fhir_r4_value_set_should_return_a_value_set():

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -920,7 +920,7 @@ def test_summarize_fhir_r4_value_set_scope_should_return_bundle():
     assert result is not None
     assert result["resourceType"] == "Bundle"
     assert len(result["entry"]) > 0
-    assert len(result["entry"]) < 10000
+    assert len(result["entry"]) <= 10000
 
 
 def test_get_fhir_r4_value_set_should_return_a_value_set():

--- a/typescript/src/api.ts
+++ b/typescript/src/api.ts
@@ -246,7 +246,7 @@ export class OrchestrateApi {
    */
   summarizeFhirR4ValueSetScope(request: SummarizeFhirR4ValueSetScopeRequest): Promise<SummarizeFhirR4ValueSetScopeResponse> {
     const params = new URLSearchParams({
-      scope: request.scope,
+      "extension.scope": request.scope,
       _summary: "true"
     });
     const route = `/terminology/v1/fhir/r4/valueset?${params.toString()}`;

--- a/typescript/tests/api.test.ts
+++ b/typescript/tests/api.test.ts
@@ -1005,7 +1005,7 @@ describe("summarize fhir r4 value set scope", () => {
     expect(result).toBeDefined();
     expect(result.resourceType).toBe("Bundle");
     expect(result.entry?.length).toBeGreaterThan(0);
-    expect(result.entry?.length).toBeLessThan(10000);
+    expect(result.entry?.length).toBeLessThanOrEqual(10000);
   }, 10000);
 });
 

--- a/typescript/tests/api.test.ts
+++ b/typescript/tests/api.test.ts
@@ -1005,6 +1005,7 @@ describe("summarize fhir r4 value set scope", () => {
     expect(result).toBeDefined();
     expect(result.resourceType).toBe("Bundle");
     expect(result.entry?.length).toBeGreaterThan(0);
+    expect(result.entry?.length).toBeLessThan(10000);
   }, 10000);
 });
 


### PR DESCRIPTION
## Description of Changes

The current version incorrectly tries to filter the FHIR endpoints by scope using `scope` when it should be `extension.scope`.

## Security

**REMINDER: All file contents are public.**

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note: No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] My changes do not introduce any security risks, or any such risks have been properly mitigated.

These parameters are manually created in the SDK, so there are no changes to user inputs or outputs.

## Reviewers

- [x] I have assigned the appropriate reviewer(s).
