### PR TITLE
Use Query Parameters for Person / Patient IDs

### DIFF
--- a/python/orchestrate/_internal/api.py
+++ b/python/orchestrate/_internal/api.py
@@ -144,13 +144,13 @@ def _get_pagination_parameters(
     return parameters
 
 
-def _get_id_dependent_route(
-    route: str,
+def _get_id_dependent_parameters(
+    id_name: str,
     id_: Optional[str] = None,
-) -> str:
+) -> dict[str, Optional[str]]:
     if id_ is not None:
-        route += f"/{quote(id_)}"
-    return route
+        return {id_name: id_}
+    return {}
 
 
 class OrchestrateApi(_HttpHandler):
@@ -946,11 +946,12 @@ class OrchestrateApi(_HttpHandler):
         <https://rosetta-api.docs.careevolution.com/convert/hl7_to_fhir.html>
         """
         headers = {"Content-Type": "text/plain"}
-        route = _get_id_dependent_route("/convert/v1/hl7tofhirr4", patient_id)
+        parameters = _get_id_dependent_parameters("patientId", patient_id)
         return self._post(
-            path=route,
+            path="/convert/v1/hl7tofhirr4",
             body=content,
             headers=headers,
+            parameters=parameters,
         )
 
     def convert_cda_to_fhir_r4(
@@ -975,11 +976,12 @@ class OrchestrateApi(_HttpHandler):
         <https://rosetta-api.docs.careevolution.com/convert/cda_to_fhir.html>
         """
         headers = {"Content-Type": "application/xml"}
-        route = _get_id_dependent_route("/convert/v1/cdatofhirr4", patient_id)
+        parameters = _get_id_dependent_parameters("patientId", patient_id)
         return self._post(
-            path=route,
+            path="/convert/v1/cdatofhirr4",
             body=content,
             headers=headers,
+            parameters=parameters,
         )
 
     def convert_cda_to_pdf(self, content: str) -> ConvertCdaToPdfResponse:
@@ -1073,11 +1075,12 @@ class OrchestrateApi(_HttpHandler):
         A FHIR R4 Bundle containing the clinical data parsed out of the X12
         """
         headers = {"Content-Type": "text/plain"}
-        route = _get_id_dependent_route("/convert/v1/x12tofhirr4", patient_id)
+        parameters = _get_id_dependent_parameters("patientId", patient_id)
         return self._post(
-            path=route,
+            path="/convert/v1/x12tofhirr4",
             body=content,
             headers=headers,
+            parameters=parameters,
         )
 
     def insight_risk_profile(
@@ -1404,7 +1407,7 @@ class OrchestrateApi(_HttpHandler):
     def convert_combined_fhir_r4_bundles(
         self,
         content: str,
-        person_id: Optional[str] = None,
+        patient_id: Optional[str] = None,
     ) -> ConvertCombinedFhirR4BundlesResponse:
         """
         This operation aggregates information retrieved from prior Convert API requests into a single entry.
@@ -1423,9 +1426,10 @@ class OrchestrateApi(_HttpHandler):
         <https://rosetta-api.docs.careevolution.com/convert/combine_bundles.html>
         """
         headers = {"Content-Type": "application/x-ndjson"}
-        route = _get_id_dependent_route("/convert/v1/combinefhirr4bundles", person_id)
+        parameters = _get_id_dependent_parameters("patientId", patient_id)
         return self._post(
-            path=route,
+            path="/convert/v1/combinefhirr4bundles",
             body=content,
             headers=headers,
+            parameters=parameters,
         )

--- a/python/orchestrate/_internal/api.py
+++ b/python/orchestrate/_internal/api.py
@@ -147,7 +147,7 @@ def _get_pagination_parameters(
 def _get_id_dependent_parameters(
     id_name: str,
     id_: Optional[str] = None,
-) -> dict[str, Optional[str]]:
+) -> dict[str, str]:
     if id_ is not None:
         return {id_name: id_}
     return {}

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -1058,7 +1058,7 @@ def test_convert_combined_fhir_r4_bundles_with_person_should_combine():
     )
 
     result = TEST_API.convert_combined_fhir_r4_bundles(
-        content=bundles, person_id="1234"
+        content=bundles, patient_id="1234"
     )
 
     assert result is not None
@@ -1130,7 +1130,7 @@ def test_convert_x12_to_fhir_r4_should_return_a_bundle():
 
 
 def test_convert_x12_to_fhir_r4_with_patient_should_return_a_bundle():
-    result = TEST_API.convert_x12_to_fhir_r4(content=_X12_DOCUMENT, patient_id="1234")
+    result = TEST_API.convert_x12_to_fhir_r4(content=_X12_DOCUMENT, patient_id="12/34")
 
     assert result is not None
     assert result["resourceType"] == "Bundle"
@@ -1142,7 +1142,7 @@ def test_convert_x12_to_fhir_r4_with_patient_should_return_a_bundle():
             if entry["resource"]["resourceType"] == "Patient"
         )
     )
-    assert patient_resource["id"] == "1234"
+    assert patient_resource["id"] == "12/34"
 
 
 def test_get_fhir_r4_code_system_should_return_a_code_system():

--- a/typescript/src/api.ts
+++ b/typescript/src/api.ts
@@ -439,7 +439,7 @@ export class OrchestrateApi {
       parameters.append("ra_segment", request.raSegment);
     }
     let route = "/insight/v1/riskprofile";
-    if (parameters.toString()) {
+    if (parameters.size) {
       route += `?${parameters.toString()}`;
     }
     return this.httpHandler.post(route, request.content);
@@ -460,7 +460,7 @@ export class OrchestrateApi {
       parameters.append("patientId", request.patientID);
     }
     let route = "/convert/v1/hl7tofhirr4";
-    if (parameters.toString()) {
+    if (parameters.size) {
       route += `?${parameters.toString()}`;
     }
     return this.httpHandler.post(route, request.content, headers);
@@ -481,7 +481,7 @@ export class OrchestrateApi {
       parameters.append("patientId", request.patientID);
     }
     let route = "/convert/v1/cdatofhirr4";
-    if (parameters.toString()) {
+    if (parameters.size) {
       route += `?${parameters.toString()}`;
     }
     return this.httpHandler.post(route, request.content, headers);
@@ -541,7 +541,7 @@ export class OrchestrateApi {
       parameters.append("patientId", request.patientID);
     }
     let route = "/convert/v1/combinefhirr4bundles";
-    if (parameters.toString()) {
+    if (parameters.size) {
       route += `?${parameters.toString()}`;
     }
     return this.httpHandler.post(route, request.content, headers);
@@ -561,7 +561,7 @@ export class OrchestrateApi {
       parameters.append("patientId", request.patientID);
     }
     let route = "/convert/v1/x12tofhirr4";
-    if (parameters.toString()) {
+    if (parameters.size) {
       route += `?${parameters.toString()}`;
     }
     return this.httpHandler.post(route, request.content, headers);

--- a/typescript/src/api.ts
+++ b/typescript/src/api.ts
@@ -457,7 +457,7 @@ export class OrchestrateApi {
     } as { [key: string]: string; };
     const parameters = new URLSearchParams();
     if (request.patientID) {
-      parameters.append("patientID", request.patientID);
+      parameters.append("patientId", request.patientID);
     }
     let route = "/convert/v1/hl7tofhirr4";
     if (parameters.toString()) {
@@ -478,7 +478,7 @@ export class OrchestrateApi {
     } as { [key: string]: string; };
     const parameters = new URLSearchParams();
     if (request.patientID) {
-      parameters.append("patientID", request.patientID);
+      parameters.append("patientId", request.patientID);
     }
     let route = "/convert/v1/cdatofhirr4";
     if (parameters.toString()) {
@@ -538,7 +538,7 @@ export class OrchestrateApi {
     } as { [key: string]: string; };
     const parameters = new URLSearchParams();
     if (request.patientID) {
-      parameters.append("patientID", request.patientID);
+      parameters.append("patientId", request.patientID);
     }
     let route = "/convert/v1/combinefhirr4bundles";
     if (parameters.toString()) {
@@ -558,7 +558,7 @@ export class OrchestrateApi {
     } as { [key: string]: string; };
     const parameters = new URLSearchParams();
     if (request.patientID) {
-      parameters.append("patientID", request.patientID);
+      parameters.append("patientId", request.patientID);
     }
     let route = "/convert/v1/x12tofhirr4";
     if (parameters.toString()) {

--- a/typescript/src/api.ts
+++ b/typescript/src/api.ts
@@ -455,7 +455,14 @@ export class OrchestrateApi {
     const headers = {
       "Content-Type": "text/plain",
     } as { [key: string]: string; };
-    const route = this.getIDDependentRoute("/convert/v1/hl7tofhirr4", request.patientID);
+    const parameters = new URLSearchParams();
+    if (request.patientID) {
+      parameters.append("patientID", request.patientID);
+    }
+    let route = "/convert/v1/hl7tofhirr4";
+    if (parameters.toString()) {
+      route += `?${parameters.toString()}`;
+    }
     return this.httpHandler.post(route, request.content, headers);
   }
 
@@ -469,7 +476,14 @@ export class OrchestrateApi {
     const headers = {
       "Content-Type": "application/xml",
     } as { [key: string]: string; };
-    const route = this.getIDDependentRoute("/convert/v1/cdatofhirr4", request.patientID);
+    const parameters = new URLSearchParams();
+    if (request.patientID) {
+      parameters.append("patientID", request.patientID);
+    }
+    let route = "/convert/v1/cdatofhirr4";
+    if (parameters.toString()) {
+      route += `?${parameters.toString()}`;
+    }
     return this.httpHandler.post(route, request.content, headers);
   }
 
@@ -522,7 +536,14 @@ export class OrchestrateApi {
     const headers = {
       "Content-Type": "application/x-ndjson",
     } as { [key: string]: string; };
-    const route = this.getIDDependentRoute("/convert/v1/combinefhirr4bundles", request.personID);
+    const parameters = new URLSearchParams();
+    if (request.patientID) {
+      parameters.append("patientID", request.patientID);
+    }
+    let route = "/convert/v1/combinefhirr4bundles";
+    if (parameters.toString()) {
+      route += `?${parameters.toString()}`;
+    }
     return this.httpHandler.post(route, request.content, headers);
   }
 
@@ -535,7 +556,14 @@ export class OrchestrateApi {
     const headers = {
       "Content-Type": "text/plain",
     } as { [key: string]: string; };
-    const route = this.getIDDependentRoute("/convert/v1/x12tofhirr4", request.patientID);
+    const parameters = new URLSearchParams();
+    if (request.patientID) {
+      parameters.append("patientID", request.patientID);
+    }
+    let route = "/convert/v1/x12tofhirr4";
+    if (parameters.toString()) {
+      route += `?${parameters.toString()}`;
+    }
     return this.httpHandler.post(route, request.content, headers);
   }
 

--- a/typescript/src/convert.ts
+++ b/typescript/src/convert.ts
@@ -36,13 +36,13 @@ export type ConvertFhirR4ToOmopResponse = Buffer;
 
 export type ConvertCombineFhirR4BundlesRequest = {
   content: string;
-  personID?: string;
+  patientID?: string;
 };
 
 export function generateConvertCombinedFhirBundlesRequestFromBundles(fhirBundles: Bundle[], personID?: string) {
   const bundles = fhirBundles.map((bundle) => JSON.stringify(bundle)).join("\n");
   return {
-    personID: personID,
+    patientID: personID,
     content: bundles,
   } as ConvertCombineFhirR4BundlesRequest;
 }

--- a/typescript/tests/api.test.ts
+++ b/typescript/tests/api.test.ts
@@ -879,14 +879,14 @@ describe("convert hl7 to fhir r4", () => {
   it("should convert hl7 with patient", async () => {
     const result = await orchestrate.convertHl7ToFhirR4({
       content: hl7,
-      patientID: "1234"
+      patientID: "12/34"
     });
     expect(result).toBeDefined();
     expect(result.resourceType).toBe("Bundle");
     expect(result.entry?.length).toBeGreaterThan(0);
     const patientResource = result.entry?.find((entry) => entry.resource?.resourceType === "Patient");
     expect(patientResource).toBeDefined();
-    expect(patientResource?.resource?.id).toBe("1234");
+    expect(patientResource?.resource?.id).toBe("12/34");
   });
 });
 
@@ -1210,7 +1210,7 @@ ${JSON.stringify(fhir)}
 
     const result = await orchestrate.convertCombinedFhirR4Bundles({
       content: bundles,
-      personID: "1234"
+      patientID: "1234"
     });
 
     expect(result).toBeDefined();


### PR DESCRIPTION
## Description of Changes

This changes the internals of how patient IDs and person IDs are supplied to the API.

This creates a breaking change, because the combine operation previously accepted a `person_id`/`personID` and now takes a `patient_id`/`patientID`. The SDK was largely ignoring the change until now, but because the API is now looking for specific keys, we need to break the signature.

## Issue Link

Resolves <https://github.com/CareEvolution/OrchestrateSDK/issues/88>

## Security

**REMINDER: All file contents are public.**

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note: No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] My changes do not introduce any security risks, or any such risks have been properly mitigated.

Because the user-supplied identifiers are no longer part of the URL route requested from API, this should be a general improvement to the security posture. We no longer quote the value provided by the user, but that should be handled by `requests`.

## Reviewers

- [x] I have assigned the appropriate reviewer(s).
