### PR TITLE
Fix some buildy things

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -4,8 +4,9 @@
 	"description": "A TypeScript client for the Orchestrate API",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
+	"type": "module",
 	"scripts": {
-		"build": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json && node ./scripts/build-esm-package.mjs",
+		"build": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json && node ./scripts/build-cjs-package.mjs",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"fmt": "prettier --check .",

--- a/typescript/scripts/build-cjs-package.mjs
+++ b/typescript/scripts/build-cjs-package.mjs
@@ -1,0 +1,8 @@
+import { writeFile } from "fs";
+
+const content = JSON.stringify({ type: "commonjs" });
+writeFile("./dist/cjs/package.json", content, (err) => {
+	if (err) {
+		throw err;
+	}
+});

--- a/typescript/scripts/build-esm-package.mjs
+++ b/typescript/scripts/build-esm-package.mjs
@@ -1,8 +1,0 @@
-import { writeFile } from "fs";
-
-const content = JSON.stringify({ type: "module" });
-writeFile("./dist/esm/package.json", content, (err) => {
-	if (err) {
-		throw err;
-	}
-});

--- a/typescript/src/api.ts
+++ b/typescript/src/api.ts
@@ -1,7 +1,7 @@
-import { ConvertApi } from "./convert";
-import { createHttpHandler } from "./httpHandlerFactory";
-import { InsightApi } from "./insight";
-import { TerminologyApi } from "./terminology";
+import { ConvertApi } from "./convert.js";
+import { createHttpHandler } from "./httpHandlerFactory.js";
+import { InsightApi } from "./insight.js";
+import { TerminologyApi } from "./terminology.js";
 
 export interface Configuration {
   apiKey?: string;

--- a/typescript/src/convert.ts
+++ b/typescript/src/convert.ts
@@ -1,4 +1,4 @@
-import { Bundle } from "fhir/r4";
+import type { Bundle } from "fhir/r4.js";
 import { IHttpHandler } from "./httpHandler.js";
 
 export type ConvertHl7ToFhirR4Request = {

--- a/typescript/src/httpHandlerFactory.ts
+++ b/typescript/src/httpHandlerFactory.ts
@@ -1,4 +1,4 @@
-import { HttpHandler, IHttpHandler } from "./httpHandler";
+import { HttpHandler, IHttpHandler } from "./httpHandler.js";
 
 function getPriorityBaseUrl(): string {
   return process.env.ORCHESTRATE_BASE_URL || "https://api.careevolutionapi.com";

--- a/typescript/src/insight.ts
+++ b/typescript/src/insight.ts
@@ -1,4 +1,4 @@
-import { Bundle, MeasureReport, Measure, Patient, RiskAssessment, OperationOutcome } from "fhir/r4";
+import { Bundle, MeasureReport, Measure, Patient, RiskAssessment, OperationOutcome } from "fhir/r4.js";
 import { IHttpHandler } from "./httpHandler.js";
 
 const raSegments = [

--- a/typescript/src/terminology.ts
+++ b/typescript/src/terminology.ts
@@ -7,9 +7,9 @@ import {
   Parameters,
   ParametersParameter,
   ValueSet,
-} from "fhir/r4";
-import { IHttpHandler } from "./httpHandler";
-import { handleBatchOverload } from "./batch";
+} from "fhir/r4.js";
+import { IHttpHandler } from "./httpHandler.js";
+import { handleBatchOverload } from "./batch.js";
 
 const standardizeTargetSystems = [
   "ICD-10-CM",

--- a/typescript/tsconfig.cjs.json
+++ b/typescript/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.esm.json",
   "compilerOptions": {
     "module": "CommonJS",
+    "moduleResolution": "node",
     "outDir": "./dist/cjs"
   }
 }

--- a/typescript/tsconfig.esm.json
+++ b/typescript/tsconfig.esm.json
@@ -2,11 +2,11 @@
   "compilerOptions": {
     "strict": true,
     "declaration": true,
-    "lib": ["dom", "ES6"],
+    "lib": [ "ES6"],
     "target": "ES6",
-    "module": "ES6",
+    "module": "NodeNext",
     "outDir": "dist/esm",
-    "moduleResolution": "node",
+    "moduleResolution": "NodeNext",
     "types": ["node"],
     "esModuleInterop": true
   },

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -3,7 +3,6 @@
 		"strict": true,
 		"declaration": false,
 		"lib": [
-			"dom",
 			"ES6"
 		],
 		"target": "ES6",


### PR DESCRIPTION
Key insight was that in order for us to get expected behavior in editor (like highlighting import errors), we needed to have `type: "module"` set in the package.json.

Then we can build esm with expected parameters (module: nodeNext).

This means we needed to invert the `build-esm-package.mjs` script to add the `package.json `with `type:"commonjs"` set in the cjs export instead
