### PR TITLE
Send Bytes in Python

### DIFF
--- a/python/tests/data/encoding_cda.xml
+++ b/python/tests/data/encoding_cda.xml
@@ -1,0 +1,46 @@
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:hl7-org:v3" moodCode="EVN">
+  <typeId extension="POCD_HD000040" root="2.16.840.1.113883.1.3" />
+  <templateId root="2.16.840.1.113883.10.20.1" />
+  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.1" />
+  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.2" />
+  <id extension="326541157" root="6.14.983.0.653038.8.1114.0.7" />
+  <code code="34133-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Summarization of Episode Note" />
+  <title>Minute Clinic Continuity of Care Document</title>
+  <effectiveTime value="20170830091100-0400" />
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" codeSystemName="Confidentiality" displayName="Normal" />
+  <languageCode code="en-US" />
+  <setId assigningAuthorityName="EPC" extension="52a22bb4-d0f5-441f-89a8-d204e21c4445" root="1.2.3.4.5.6.1.13.418.3.7.1.1" />
+  <versionNumber value="1" />
+  <recordTarget contextControlCode="OP" typeCode="RCT">
+    <patientRole classCode="PAT">
+      <id extension="H60863152" root="1.2.3.4.5.1.7" />
+      <patient classCode="PSN" determinerCode="INSTANCE">
+        <name use="L">
+          <given>George</given>
+          <family>Example</family>
+        </name>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <component>
+    <structuredBody classCode="DOCBODY" moodCode="EVN">
+      <component>
+        <section>
+          <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.4" />
+          <id root="f49b7e6f-c9f8-4f31-abd8-9b531dfc714e" />
+          <code code="10164-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="History of Present Illness" />
+          <title>Progress Notes</title>
+          <text mediaType="text/x-hl7-text+xml">
+            <list styleCode="TOC">
+              <item>
+                <caption>War, Jo - 07/31/2007 9:02 AM EST</caption>
+                <paragraph>Smoking Status   � Never Smoker   Smokeless Tobacco   � Not on file</paragraph>
+              </item>
+            </list>
+          </text>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -839,3 +839,12 @@ def test_convert_cda_to_html_should_convert():
 
     assert result is not None
     assert result.startswith("<html")
+
+
+def test_convert_cda_to_fhir_r4_alternative_encoding_should_send_bytes():
+    file = Path(__file__).parent / "data" / "encoding_cda.xml"
+
+    result = TEST_API.convert.cda_to_fhir_r4(content=file.read_text())
+
+    assert result is not None
+    assert result["resourceType"] == "Bundle"


### PR DESCRIPTION
## Description of Changes

The requests library seems to be handling the `data` parameter it accepts in `POST`s in such a way to cause differently-encoded strings to fail when passing to Orchestrate. This PR changes the behavior of the Python library so that it always passes bytes to the `requests` library. None of the signatures have changed.

## Security

**REMINDER: All file contents are public.**

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note: No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] My changes do not introduce any security risks, or any such risks have been properly mitigated.

This only changes the encoding of values passed to Orchestrate.

## Reviewers

- [x] I have assigned the appropriate reviewer(s).
