### PR TITLE
Add Timezone for HL7toFHIR

### DIFF
--- a/python/orchestrate/_internal/convert.py
+++ b/python/orchestrate/_internal/convert.py
@@ -71,6 +71,7 @@ class ConvertApi:
         self,
         content: str,
         patient_id: Optional[str] = None,
+        tz: Optional[str] = None,
     ) -> ConvertHl7ToFhirR4Response:
         """
         Converts one or more HL7v2 messages into a FHIR R4 bundle
@@ -79,6 +80,7 @@ class ConvertApi:
 
         - `hl7_message`: The HL7 message(s) to convert
         - `patient_id`: The patient ID to use for the FHIR bundle
+        - `tz`: The timezone to use for the FHIR bundle. Must be IANA or Windows timezone name. Defaults to UTC.
 
         ### Returns
 
@@ -90,6 +92,7 @@ class ConvertApi:
         """
         headers = {"Content-Type": "text/plain"}
         parameters = _get_id_dependent_parameters("patientId", patient_id)
+        parameters = {**parameters, **_get_id_dependent_parameters("tz", tz)}
         return self.__http_handler.post(
             path="/convert/v1/hl7tofhirr4",
             body=content,

--- a/python/orchestrate/_internal/convert.py
+++ b/python/orchestrate/_internal/convert.py
@@ -80,7 +80,7 @@ class ConvertApi:
 
         - `hl7_message`: The HL7 message(s) to convert
         - `patient_id`: The patient ID to use for the FHIR bundle
-        - `tz`: The timezone to use for the FHIR bundle. Must be IANA or Windows timezone name. Defaults to UTC.
+        - `tz`: Default timezone for date-times in the HL7 when no timezone offset is present. Must be IANA or Windows timezone name. Defaults to UTC.
 
         ### Returns
 

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -488,6 +488,38 @@ def test_api_convert_hl7_to_fhir_r4_with_patient_should_convert():
     assert patient_resource["id"] == "1234"
 
 
+def test_api_convert_hl7_to_fhir_r4_with_timezone_should_convert():
+    result = TEST_API.convert.hl7_to_fhir_r4(content=HL7, tz="America/New_York")
+
+    assert result is not None
+    assert result["resourceType"] == "Bundle"
+    assert len(result["entry"]) > 0
+    encounter = next(
+        (
+            entry["resource"]
+            for entry in result["entry"]
+            if entry["resource"]["resourceType"] == "Encounter"
+        )
+    )
+    assert encounter["period"]["start"] == "2014-11-07T14:40:00-05:00"
+
+
+def test_api_convert_hl7_to_fhir_r4_without_timezone_should_presume_utc():
+    result = TEST_API.convert.hl7_to_fhir_r4(content=HL7)
+
+    assert result is not None
+    assert result["resourceType"] == "Bundle"
+    assert len(result["entry"]) > 0
+    encounter = next(
+        (
+            entry["resource"]
+            for entry in result["entry"]
+            if entry["resource"]["resourceType"] == "Encounter"
+        )
+    )
+    assert encounter["period"]["start"] == "2014-11-07T14:40:00+00:00"
+
+
 def test_convert_cda_to_fhir_r4_without_patient_should_convert():
     result = TEST_API.convert.cda_to_fhir_r4(content=CDA)
 

--- a/typescript/src/convert.ts
+++ b/typescript/src/convert.ts
@@ -4,6 +4,7 @@ import { IHttpHandler } from "./httpHandler.js";
 export type ConvertHl7ToFhirR4Request = {
   content: string;
   patientID?: string;
+  tz?: string;
 };
 
 export type ConvertHl7ToFhirR4Response = Bundle;
@@ -102,6 +103,9 @@ export class ConvertApi {
   /**
    * Converts one or more HL7v2 messages into a FHIR R4 bundle
    * @param request A single or newline-delimited set of HL7v2.7 messages
+   *  - `content` The HL7v2.7 messages to convert
+   *  - `patientID` The patient ID to associate with the clinical data
+   *  - `tz` The timezone to use when parsing dates and times. Must be IANA or Windows timezone format. If not provided, defaults to UTC.
    * @returns A FHIR R4 Bundle containing the clinical data parsed out of the HL7 messages
    * @link https://rosetta-api.docs.careevolution.com/convert/hl7_to_fhir.html
    */
@@ -112,6 +116,9 @@ export class ConvertApi {
     const parameters = new URLSearchParams();
     if (request.patientID) {
       parameters.append("patientId", request.patientID);
+    }
+    if (request.tz) {
+      parameters.append("tz", request.tz);
     }
     let route = "/convert/v1/hl7tofhirr4";
     if (parameters.size) {

--- a/typescript/src/convert.ts
+++ b/typescript/src/convert.ts
@@ -105,7 +105,7 @@ export class ConvertApi {
    * @param request A single or newline-delimited set of HL7v2.7 messages
    *  - `content` The HL7v2.7 messages to convert
    *  - `patientID` The patient ID to associate with the clinical data
-   *  - `tz` The timezone to use when parsing dates and times. Must be IANA or Windows timezone format. If not provided, defaults to UTC.
+   *  - `tz`: Default timezone for date-times in the HL7 when no timezone offset is present. Must be IANA or Windows timezone name. Defaults to UTC.
    * @returns A FHIR R4 Bundle containing the clinical data parsed out of the HL7 messages
    * @link https://rosetta-api.docs.careevolution.com/convert/hl7_to_fhir.html
    */


### PR DESCRIPTION

## Description of Changes

This adds support for the `tz` parameter in `hl7ToFhirR4` endpoints. This parameter allows the user to specify the timezone of the incoming HL7 message. If the `tz` parameter is not provided, the server will default to using UTC.

Related: <https://github.com/CareEvolution/Hendrix/pull/691>

## Security

**REMINDER: All file contents are public.**

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note: No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] My changes do not introduce any security risks, or any such risks have been properly mitigated.

This uses the existing `patientId` query parameter to specify the timezone, including parameter quoting, to ensure that the timezone is properly parsed and used.

## Reviewers

- [x] I have assigned the appropriate reviewer(s).
