### PR TITLE
Add FHIR R4 to Manifest

### DIFF
--- a/python/orchestrate/_internal/insight.py
+++ b/python/orchestrate/_internal/insight.py
@@ -32,6 +32,8 @@ class InsightBundle(TypedDict):
 
 InsightRiskProfileResponse = InsightBundle
 
+InsightFhirR4ToManifestResponse = bytes
+
 
 class InsightApi:
     def __init__(self, http_handler: HttpHandler) -> None:
@@ -68,7 +70,7 @@ class InsightApi:
 
         ### Documentation
 
-        <
+        <https://orchestrate.docs.careevolution.com/insight/risk_profile.html>
         """
         parameters = {
             "hccVersion": hcc_version,
@@ -79,4 +81,33 @@ class InsightApi:
             path="/insight/v1/riskprofile",
             body=content,
             parameters=parameters,
+        )
+
+    def fhir_r4_to_manifest(self, content: Bundle) -> InsightFhirR4ToManifestResponse:
+        """
+        Generates a tabular report of clinical concepts from a FHIR R4
+        bundle. With this tabular data, you can easily scan results, run
+        queries, and understand the value of your clinical data.
+
+        ### Parameters
+
+        - `content`: A FHIR R4 bundle
+
+        ### Returns
+
+        A ZIP file containing a number of Comma-Separated Value (CSV)
+        files corresponding to clinical concepts (conditions,
+        encounters, etc.).
+
+        ### Documentation
+
+        <https://orchestrate.docs.careevolution.com/insight/fhir_manifest.html>
+        """
+        headers = {
+            "Accept": "application/zip",
+        }
+        return self.__http_handler.post(
+            path="/insight/v1/fhirr4tomanifest",
+            body=content,
+            headers=headers,
         )

--- a/python/orchestrate/insight.py
+++ b/python/orchestrate/insight.py
@@ -2,10 +2,12 @@ from orchestrate._internal.insight import (
     InsightBundle,
     InsightBundleEntry,
     InsightRiskProfileResponse,
+    InsightFhirR4ToManifestResponse,
 )
 
 __all__ = [
     "InsightBundle",
     "InsightBundleEntry",
     "InsightRiskProfileResponse",
+    "InsightFhirR4ToManifestResponse",
 ]

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -897,3 +897,21 @@ def test_convert_fhir_r4_to_nemsis_v35_should_convert():
     assert result is not None
     assert "<EMSDataSet" in result
     assert "<eOutcome.18" in result
+
+
+def test_insight_fhir_r4_to_manifest_should_have_csvs():
+    result = TEST_API.insight.fhir_r4_to_manifest(content=R4_BUNDLE)
+
+    assert result is not None
+    assert isinstance(result, bytes)
+    with ZipFile(BytesIO(result)) as zip_file:
+        assert all(
+            file in [csv.filename for csv in zip_file.infolist()]
+            for file in [
+                "patients.csv",
+                "encounters.csv",
+                "procedures.csv",
+                "conditions.csv",
+            ]
+        )
+        assert all(file.filename.endswith(".csv") and file.file_size > 0 for file in zip_file.infolist())

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -914,4 +914,7 @@ def test_insight_fhir_r4_to_manifest_should_have_csvs():
                 "conditions.csv",
             ]
         )
-        assert all(file.filename.endswith(".csv") and file.file_size > 0 for file in zip_file.infolist())
+        assert all(
+            file.filename.endswith(".csv") and file.file_size > 0
+            for file in zip_file.infolist()
+        )

--- a/typescript/src/convert.ts
+++ b/typescript/src/convert.ts
@@ -1,4 +1,4 @@
-import type { Bundle } from "fhir/r4.js";
+import { Bundle } from "fhir/r4.js";
 import { IHttpHandler } from "./httpHandler.js";
 
 export type ConvertHl7ToFhirR4Request = {
@@ -22,7 +22,7 @@ export type ConvertCdaToPdfRequest = {
   content: string;
 };
 
-export type ConvertCdaToPdfResponse = Buffer;
+export type ConvertCdaToPdfResponse = ArrayBuffer;
 
 export type ConvertFhirR4ToCdaRequest = {
   content: Bundle;
@@ -34,7 +34,7 @@ export type ConvertFhirR4ToOmopRequest = {
   content: Bundle;
 };
 
-export type ConvertFhirR4ToOmopResponse = Buffer;
+export type ConvertFhirR4ToOmopResponse = ArrayBuffer;
 
 export type ConvertCombineFhirR4BundlesRequest = {
   content: string;
@@ -159,7 +159,7 @@ export class ConvertApi {
       "Content-Type": "application/xml",
       Accept: "application/pdf",
     } as { [key: string]: string; };
-    return this.httpHandler.post("/convert/v1/cdatopdf", request.content, headers);
+    return this.httpHandler.post<string, ArrayBuffer>("/convert/v1/cdatopdf", request.content, headers);
   }
 
   /**
@@ -184,7 +184,11 @@ export class ConvertApi {
     const headers = {
       Accept: "application/zip",
     } as { [key: string]: string; };
-    return this.httpHandler.post("/convert/v1/fhirr4toomop", request.content, headers);
+    return this.httpHandler.post<Bundle, ArrayBuffer>(
+      "/convert/v1/fhirr4toomop",
+      request.content,
+      headers
+    );
   }
 
   /**

--- a/typescript/src/insight.ts
+++ b/typescript/src/insight.ts
@@ -22,6 +22,12 @@ export type InsightRiskProfileResource = Patient | MeasureReport | Measure | Ris
 
 export type InsightRiskProfileResponse = Bundle<InsightRiskProfileResource>;
 
+export type InsightFhirR4ToManifestRequest = {
+  content: Bundle;
+};
+
+export type InsightFhirR4ToManifestResponse = ArrayBuffer;
+
 export class InsightApi {
   private httpHandler: IHttpHandler;
 
@@ -50,5 +56,19 @@ export class InsightApi {
       route += `?${parameters.toString()}`;
     }
     return this.httpHandler.post(route, request.content);
+  }
+
+  /**
+   * Generates a tabular report of clinical concepts from a FHIR R4 bundle. With this tabular data, you can easily scan results, run queries, and understand the value of your clinical data.
+   * @param bundle A FHIR R4 Bundle
+   * @returns A ZIP file containing a number of Comma-Separated Value (CSV) files corresponding to clinical concepts (conditions, encounters, etc.).
+   * @link https://rosetta-api.docs.careevolution.com/insight/fhir_manifest.html
+   */
+  fhirR4ToManifest(request: InsightFhirR4ToManifestRequest): Promise<InsightFhirR4ToManifestResponse> {
+    return this.httpHandler.post<Bundle, ArrayBuffer>(
+      "/insight/v1/fhirr4tomanifest",
+      request.content,
+      { "Accept": "application/zip" }
+    );
   }
 }

--- a/typescript/tests/api.test.ts
+++ b/typescript/tests/api.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect, test } from "vitest";
 
 dotenv.config({ path: "../.env" });
 const orchestrate = new OrchestrateApi();
+const pkZipMagicNumber = new Int8Array([80, 75, 3, 4]);
 
 describe("classify condition", () => {
   const requests: ClassifyConditionRequest[] = [
@@ -383,8 +384,8 @@ describe("convert cda to pdf", () => {
     });
     expect(result).toBeDefined();
     const resultIntegers = new Int8Array(result);
-    // Check for PDF magic number
-    expect(resultIntegers.slice(0, 4)).toStrictEqual(new Int8Array([37, 80, 68, 70]));
+    const pdfMagicNumber = new Int8Array([37, 80, 68, 70]);
+    expect(resultIntegers.slice(0, 4)).toStrictEqual(pdfMagicNumber);
   });
 });
 
@@ -405,8 +406,7 @@ describe("convert fhir r4 to omop", () => {
     });
     expect(result).toBeDefined();
     const resultIntegers = new Int8Array(result);
-    // Check for PKZip magic number
-    expect(resultIntegers.slice(0, 4)).toStrictEqual(new Int8Array([80, 75, 3, 4]));
+    expect(resultIntegers.slice(0, 4)).toStrictEqual(pkZipMagicNumber);
   });
 });
 
@@ -765,5 +765,18 @@ describe("convert fhir r4 to nemsis v35", () => {
     expect(result).toBeDefined();
     expect(result).toContain("<EMSDataSet");
     expect(result).toContain("<eOutcome.18");
+  });
+});
+
+describe("insight fhir r4 to manifest", async () => {
+  it("should return a buffer", async () => {
+    const result = await orchestrate.insight.fhirR4ToManifest({
+      content: fhir,
+    });
+
+    expect(result).toBeDefined();
+    console.log(typeof result);
+    const resultIntegers = new Int8Array(result);
+    expect(resultIntegers.slice(0, 4)).toStrictEqual(pkZipMagicNumber);
   });
 });

--- a/typescript/tests/identity/api.test.ts
+++ b/typescript/tests/identity/api.test.ts
@@ -71,7 +71,7 @@ async function createRandomRecord(): Promise<{ person: Person; identifier: strin
 }
 
 describe("Identity API addOrUpdateRecord", () => {
-  it("should add a new record", { timeout: 30000 }, async () => {
+  it("should add a new record", { timeout: 300000 }, async () => {
     const addResponse = await identityApi.addOrUpdateRecord({
       source: defaultSource,
       identifier: Math.random().toString(36).substring(7),
@@ -82,7 +82,7 @@ describe("Identity API addOrUpdateRecord", () => {
     expect(addResponse.matchedPerson.id).toBeDefined();
   });
 
-  it("with url unsafe identifier should add record", { timeout: 30000 }, async () => {
+  it("with url unsafe identifier should add record", { timeout: 300000 }, async () => {
     const addResponse = await identityApi.addOrUpdateRecord({
       source: defaultSource,
       identifier: Math.random().toString(36).substring(7) + "+/=",
@@ -95,7 +95,7 @@ describe("Identity API addOrUpdateRecord", () => {
 });
 
 describe("Identity API addOrUpdateBlindedRecord", () => {
-  it("should add a new record", { timeout: 30000 }, async () => {
+  it("should add a new record", { timeout: 300000 }, async () => {
     const addResponse = await identityApi.addOrUpdateBlindedRecord({
       source: defaultSource,
       identifier: Math.random().toString(36).substring(7),
@@ -106,7 +106,7 @@ describe("Identity API addOrUpdateBlindedRecord", () => {
     expect(addResponse.matchedPerson.id).toBeDefined();
   });
 
-  it("with url unsafe identifier should add record", { timeout: 30000 }, async () => {
+  it("with url unsafe identifier should add record", { timeout: 300000 }, async () => {
     const addResponse = await identityApi.addOrUpdateBlindedRecord({
       source: defaultSource,
       identifier: Math.random().toString(36).substring(7),
@@ -119,7 +119,7 @@ describe("Identity API addOrUpdateBlindedRecord", () => {
 });
 
 describe("Identity API getPersonByRecord", () => {
-  it("should get a person by record", { timeout: 30000 }, async () => {
+  it("should get a person by record", { timeout: 300000 }, async () => {
     const { person, identifier } = await createRandomRecord();
 
     const getResponse = await identityApi.getPersonByRecord({
@@ -132,7 +132,7 @@ describe("Identity API getPersonByRecord", () => {
 });
 
 describe("Identity API getPersonByID", () => {
-  it("should get a person by ID", { timeout: 30000 }, async () => {
+  it("should get a person by ID", { timeout: 300000 }, async () => {
     const { person } = await createRandomRecord();
 
     const getResponse = await identityApi.getPersonByID({
@@ -144,7 +144,7 @@ describe("Identity API getPersonByID", () => {
 });
 
 describe("Identity API matchDemographics", () => {
-  it("should match demographics", { timeout: 30000 }, async () => {
+  it("should match demographics", { timeout: 300000 }, async () => {
     const matchResponse = await identityApi.matchDemographics(demographic);
 
     expect(matchResponse).toBeDefined();
@@ -152,7 +152,7 @@ describe("Identity API matchDemographics", () => {
 });
 
 describe("Identity API matchBlindedDemographics", () => {
-  it("should match blinded demographics", { timeout: 30000 }, async () => {
+  it("should match blinded demographics", { timeout: 300000 }, async () => {
     const matchResponse = await identityApi.matchBlindedDemographics(blindedDemographic);
 
     expect(matchResponse).toBeDefined();
@@ -160,7 +160,7 @@ describe("Identity API matchBlindedDemographics", () => {
 });
 
 describe("Identity API deleteRecord", () => {
-  it("should delete a record", { timeout: 30000 }, async () => {
+  it("should delete a record", { timeout: 300000 }, async () => {
     const { person, identifier } = await createRandomRecord();
 
     const deleteResponse = await identityApi.deleteRecord({
@@ -173,7 +173,7 @@ describe("Identity API deleteRecord", () => {
 });
 
 describe("Identity API addMatchGuidance", () => {
-  it("should add match guidance", { timeout: 30000 }, async () => {
+  it("should add match guidance", { timeout: 300000 }, async () => {
     const { person: firstPerson, identifier: firstIdentifier } = await createRandomRecord();
     const { person: secondPerson, identifier: secondIdentifier } = await createRandomRecord();
 
@@ -190,7 +190,7 @@ describe("Identity API addMatchGuidance", () => {
 });
 
 describe("Identity API removeMatchGuidance", () => {
-  it("should remove match guidance", { timeout: 30000 }, async () => {
+  it("should remove match guidance", { timeout: 300000 }, async () => {
     const { person: firstPerson, identifier: firstIdentifier } = await createRandomRecord();
     const { person: secondPerson, identifier: secondIdentifier } = await createRandomRecord();
     const recordOne = { source: defaultSource, identifier: firstIdentifier };
@@ -218,7 +218,7 @@ describe("Identity Metrics API", () => {
     await createRandomRecord();
   });
 
-  it("should have identifier metrics", { timeout: 30000 }, async () => {
+  it("should have identifier metrics", { timeout: 300000 }, async () => {
 
     const identifierMetricsResponse = await identityApi.monitoring.identifierMetrics();
 
@@ -232,7 +232,7 @@ describe("Identity Metrics API", () => {
     expect(identifierMetricsResponse.sourceTotals).toBeDefined();
   });
 
-  it("should return overlap metrics", { timeout: 30000 }, async () => {
+  it("should return overlap metrics", { timeout: 300000 }, async () => {
     const overlapMetricsResponse = await identityApi.monitoring.overlapMetrics();
 
     expect(overlapMetricsResponse).toBeDefined();

--- a/typescript/tests/identity/api.test.ts
+++ b/typescript/tests/identity/api.test.ts
@@ -71,7 +71,7 @@ async function createRandomRecord(): Promise<{ person: Person; identifier: strin
 }
 
 describe("Identity API addOrUpdateRecord", () => {
-  it("should add a new record", { timeout: 300000 }, async () => {
+  it("should add a new record", async () => {
     const addResponse = await identityApi.addOrUpdateRecord({
       source: defaultSource,
       identifier: Math.random().toString(36).substring(7),
@@ -82,7 +82,7 @@ describe("Identity API addOrUpdateRecord", () => {
     expect(addResponse.matchedPerson.id).toBeDefined();
   });
 
-  it("with url unsafe identifier should add record", { timeout: 300000 }, async () => {
+  it("with url unsafe identifier should add record", async () => {
     const addResponse = await identityApi.addOrUpdateRecord({
       source: defaultSource,
       identifier: Math.random().toString(36).substring(7) + "+/=",
@@ -95,7 +95,7 @@ describe("Identity API addOrUpdateRecord", () => {
 });
 
 describe("Identity API addOrUpdateBlindedRecord", () => {
-  it("should add a new record", { timeout: 300000 }, async () => {
+  it("should add a new record", async () => {
     const addResponse = await identityApi.addOrUpdateBlindedRecord({
       source: defaultSource,
       identifier: Math.random().toString(36).substring(7),
@@ -106,7 +106,7 @@ describe("Identity API addOrUpdateBlindedRecord", () => {
     expect(addResponse.matchedPerson.id).toBeDefined();
   });
 
-  it("with url unsafe identifier should add record", { timeout: 300000 }, async () => {
+  it("with url unsafe identifier should add record", async () => {
     const addResponse = await identityApi.addOrUpdateBlindedRecord({
       source: defaultSource,
       identifier: Math.random().toString(36).substring(7),
@@ -119,7 +119,7 @@ describe("Identity API addOrUpdateBlindedRecord", () => {
 });
 
 describe("Identity API getPersonByRecord", () => {
-  it("should get a person by record", { timeout: 300000 }, async () => {
+  it("should get a person by record", async () => {
     const { person, identifier } = await createRandomRecord();
 
     const getResponse = await identityApi.getPersonByRecord({
@@ -132,7 +132,7 @@ describe("Identity API getPersonByRecord", () => {
 });
 
 describe("Identity API getPersonByID", () => {
-  it("should get a person by ID", { timeout: 300000 }, async () => {
+  it("should get a person by ID", async () => {
     const { person } = await createRandomRecord();
 
     const getResponse = await identityApi.getPersonByID({
@@ -144,7 +144,7 @@ describe("Identity API getPersonByID", () => {
 });
 
 describe("Identity API matchDemographics", () => {
-  it("should match demographics", { timeout: 300000 }, async () => {
+  it("should match demographics", async () => {
     const matchResponse = await identityApi.matchDemographics(demographic);
 
     expect(matchResponse).toBeDefined();
@@ -152,7 +152,7 @@ describe("Identity API matchDemographics", () => {
 });
 
 describe("Identity API matchBlindedDemographics", () => {
-  it("should match blinded demographics", { timeout: 300000 }, async () => {
+  it("should match blinded demographics", async () => {
     const matchResponse = await identityApi.matchBlindedDemographics(blindedDemographic);
 
     expect(matchResponse).toBeDefined();
@@ -160,7 +160,7 @@ describe("Identity API matchBlindedDemographics", () => {
 });
 
 describe("Identity API deleteRecord", () => {
-  it("should delete a record", { timeout: 300000 }, async () => {
+  it("should delete a record", async () => {
     const { person, identifier } = await createRandomRecord();
 
     const deleteResponse = await identityApi.deleteRecord({
@@ -173,7 +173,7 @@ describe("Identity API deleteRecord", () => {
 });
 
 describe("Identity API addMatchGuidance", () => {
-  it("should add match guidance", { timeout: 300000 }, async () => {
+  it("should add match guidance", async () => {
     const { person: firstPerson, identifier: firstIdentifier } = await createRandomRecord();
     const { person: secondPerson, identifier: secondIdentifier } = await createRandomRecord();
 
@@ -190,7 +190,7 @@ describe("Identity API addMatchGuidance", () => {
 });
 
 describe("Identity API removeMatchGuidance", () => {
-  it("should remove match guidance", { timeout: 300000 }, async () => {
+  it("should remove match guidance", async () => {
     const { person: firstPerson, identifier: firstIdentifier } = await createRandomRecord();
     const { person: secondPerson, identifier: secondIdentifier } = await createRandomRecord();
     const recordOne = { source: defaultSource, identifier: firstIdentifier };
@@ -218,7 +218,7 @@ describe("Identity Metrics API", () => {
     await createRandomRecord();
   });
 
-  it("should have identifier metrics", { timeout: 300000 }, async () => {
+  it("should have identifier metrics", async () => {
 
     const identifierMetricsResponse = await identityApi.monitoring.identifierMetrics();
 
@@ -232,7 +232,7 @@ describe("Identity Metrics API", () => {
     expect(identifierMetricsResponse.sourceTotals).toBeDefined();
   });
 
-  it("should return overlap metrics", { timeout: 300000 }, async () => {
+  it("should return overlap metrics", async () => {
     const overlapMetricsResponse = await identityApi.monitoring.overlapMetrics();
 
     expect(overlapMetricsResponse).toBeDefined();

--- a/typescript/vitest.config.js
+++ b/typescript/vitest.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    // ...
+    testTimeout: 300000,
+    hookTimeout: 300000,
   },
 });


### PR DESCRIPTION
## Description of Changes

This adds the Insight family's FHIR R4 to Manifest endpoint, which returns a zip of CSVs for the bundle.

An example of usage with Python:

```python
from orchestrate import OrchestrateApi
from zipfile import ZipFile
import os

os.environ["ORCHESTRATE_API_KEY"] = "your-api-key"
api = OrchestrateApi()

manifest_zip = api.insight.fhir_r4_to_manifest(content=R4_BUNDLE)
with ZipFile(BytesIO(manifest_zip)) as zip_file:
    zip_file.extractall("/some/path")
```

## Security

**REMINDER: All file contents are public.**

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note: No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] My changes do not introduce any security risks, or any such risks have been properly mitigated.

The pattern of returning a Zip is fortunately already well-established. We are not attempting to interpret this zip. Similar to all other endpoints, received data is simply forwarded to the API.

## Reviewers

- [x] I have assigned the appropriate reviewer(s).
