### PR TITLE
Fix Python Concept Map Response Type

### DIFF
--- a/python/orchestrate/_internal/terminology.py
+++ b/python/orchestrate/_internal/terminology.py
@@ -328,6 +328,30 @@ class _CodeSystemBundle(TypedDict):
 
 SummarizeFhirR4CodeSystemsResponse = _CodeSystemBundle
 
+
+class ConceptMap(TypedDict):
+    resourceType: Literal["ConceptMap"]
+    id: str
+    name: str
+    status: Literal["active", "draft", "retired"]
+    url: str
+    source: str
+    target: str
+    group: list[dict[str, Any]]
+
+
+class _ConceptMapBundleEntry(TypedDict):
+    resource: ConceptMap
+
+
+class ConceptMapBundle(TypedDict):
+    id: str
+    resourceType: Literal["Bundle"]
+    entry: list[_ConceptMapBundleEntry]
+
+
+GetFhirR4ConceptMapsResponse = ConceptMapBundle
+
 TranslateFhirR4ConceptMapResponse = Parameters
 
 TranslateDomains = Literal[
@@ -1178,7 +1202,7 @@ class TerminologyApi:
         self,
         page_number: Optional[int] = None,
         page_size: Optional[int] = None,
-    ) -> GetFhirR4CodeSystemResponse:
+    ) -> GetFhirR4ConceptMapsResponse:
         """
         Describes available concept maps
 

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -690,7 +690,9 @@ def test_get_fhir_r4_concept_maps_should_return_a_bundle():
     assert result is not None
     assert result["resourceType"] == "Bundle"
     assert len(result["entry"]) > 0
-    assert all(entry["resource"]["resourceType"] == "ConceptMap" for entry in result["entry"])
+    assert all(
+        entry["resource"]["resourceType"] == "ConceptMap" for entry in result["entry"]
+    )
 
 
 def test_translate_fhir_r4_concept_map_with_code_should_translate():

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -690,6 +690,7 @@ def test_get_fhir_r4_concept_maps_should_return_a_bundle():
     assert result is not None
     assert result["resourceType"] == "Bundle"
     assert len(result["entry"]) > 0
+    assert all(entry["resource"]["resourceType"] == "ConceptMap" for entry in result["entry"])
 
 
 def test_translate_fhir_r4_concept_map_with_code_should_translate():

--- a/typescript/tests/api.test.ts
+++ b/typescript/tests/api.test.ts
@@ -497,7 +497,9 @@ describe("get fhir r4 concept maps", () => {
     expect(result).toBeDefined();
     expect(result.resourceType).toBe("Bundle");
     expect(result.entry?.length).toBeGreaterThan(0);
-    expect(result.entry?.[0].resource?.resourceType).toBe("ConceptMap");
+    result.entry?.forEach((entry) => {
+      expect(entry.resource?.resourceType).toBe("ConceptMap");
+    });
   });
 });
 


### PR DESCRIPTION
## Description of Changes

`get_fhir_r4_concept_maps` was previously mis-typed as a CodeSystem response. This PR corrects the response to be a ConceptMap response.

## Issue Link

This PR addresses the following issues:

- Resolves <https://github.com/CareEvolution/OrchestrateSDK/issues/145>

## Security

**REMINDER: All file contents are public.**

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note: No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] My changes do not introduce any security risks, or any such risks have been properly mitigated.

This does not change any functionality, only the response type.

## Reviewers

- [x] I have assigned the appropriate reviewer(s).
