### PR TITLE
Export FHIR data types in Python SDK

### DIFF
--- a/python/orchestrate/__init__.py
+++ b/python/orchestrate/__init__.py
@@ -5,6 +5,7 @@ from orchestrate import insight
 from orchestrate import convert
 from orchestrate import exceptions
 from orchestrate import identity
+from orchestrate import fhir
 
 __version__ = __version__
 
@@ -15,4 +16,5 @@ __all__ = [
     "convert",
     "exceptions",
     "identity",
+    "fhir",
 ]

--- a/python/orchestrate/_internal/fhir.py
+++ b/python/orchestrate/_internal/fhir.py
@@ -1,4 +1,4 @@
-from typing import Generic, Literal, Optional, TypeVar, TypedDict, Union
+from typing import Literal, Optional, TypedDict
 
 
 class Coding(TypedDict):

--- a/python/orchestrate/fhir.py
+++ b/python/orchestrate/fhir.py
@@ -1,0 +1,11 @@
+from orchestrate._internal.fhir import (
+    Bundle,
+    BundleEntry,
+    Resource,
+)
+
+__all__ = [
+    "Bundle",
+    "BundleEntry",
+    "Resource",
+]


### PR DESCRIPTION
## Description of Changes

The `ConvertApi` class exposes methods that both accept and return `Bundle` objects. However, `Bundle` was only defined in the internal `orchestrate._internal.fhir` module, which is not accessable to the users of the SDK. This PR creates a new public module `orchestrate.fhir` that exports essential FHIR types (`Bundle`, `BundleEntry`, and `Resource`).

However, the Typescript SDK doesn't require similar type re-exports because the Typescript implementation doesn't introduce any new custom types for FHIR resources.

## Issue Link

NA

## Security

**REMINDER: All file contents are public.**

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note: No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] My changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Reviewers

- [x] I have assigned the appropriate reviewer(s).

Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including subject-matter experts and editing/style reviewers.
