### PR TITLE
Additional parameter for FhirR4toManifest - source

### DIFF
--- a/python/orchestrate/_internal/convert.py
+++ b/python/orchestrate/_internal/convert.py
@@ -475,7 +475,7 @@ class ConvertApi:
         )
 
     def fhir_r4_to_manifest(
-        self, content: Bundle, delimiter: Optional[str] = None
+        self, content: Bundle, delimiter: Optional[str] = None, source: Optional[str] = None
     ) -> ConvertFhirR4ToManifestResponse:
         """
         Generates a tabular report of clinical concepts from a FHIR R4
@@ -486,6 +486,7 @@ class ConvertApi:
 
         - `content`: A FHIR R4 bundle
         - `delimiter`: The delimiter to use in the CSV files. Allowed delimiters are | or ~ or ^ or ; Default delimiter is ,
+        - `source`: The source of the FHIR R4 bundle to be included in the provenance file
 
         ### Returns
 
@@ -501,6 +502,10 @@ class ConvertApi:
             "Accept": "application/zip",
         }
         parameters = _get_id_dependent_parameters("delimiter", delimiter)
+        parameters = {
+            **parameters,
+            **_get_id_dependent_parameters("source", source),
+        }
         return self.__http_handler.post(
             path="/convert/v1/fhirr4tomanifest",
             body=content,


### PR DESCRIPTION
## Description of Changes

> Briefly describe the change, including justification for the change, ramifications for not doing the change, and any specific versions/configurations impacted.

Additional parameter `source` for FhirR4ToManifest API 

## Issue Link

This PR addresses the following issues:

- LINK TO RELEVANT ISSUES, IF APPLICABLE

## Security

**REMINDER: All file contents are public.**

- [ ] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note: No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [ ] My changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Change Control Board (CCB) Approval

> CCB approval is required when the change affects organizational processes (like vulnerability management or disaster recovery), or has the potential to impact availability, security, or privacy. See the CR process for more detailed assessment guidelines.

- [ ] This change does NOT require CCB approval.
- [ ] This change DOES require CCB approval. Tag `@careevolution/ccb`.

## Testing/Validation

> Describe how we will know if the change is working as intended. Consider both pre-production testing and post-implementation validation, including environment/configuration details, if applicable.

TODO: REPLACE WITH YOUR TESTING/VALIDATION PLAN

## Backout Plan

> Describe how we will restore the system to its pre-change state if something goes wrong.

TODO: REPLACE WITH YOUR BACKOUT PLAN

## Implementation Notes

> Describe any special considerations for implementing the change: scheduling constraints, down-time planning, if a co-pilot is needed, etc.

TODO: REPLACE WITH IMPLEMENTATION NOTES

## Documentation Updates

> Describe any necessary updates. Consider both internal (wiki, checklists) and external (user guides, developer docs, customer communications) documentation.

- [ ] This change has no documentation impact.
- [ ] This change impacts external documentation (API docs, user guides). Tag `@careevolution/mdhd-docs` or `@careevolution/api-docs`.
- [ ] This change impacts internal documentation (procedures, security plans, wiki). Tag the owner.

TODO: REPLACE WITH A DESCRIPTION OF DOCUMENTATION UPDATES, if applicable

## Reviewers

- [ ] I have assigned the appropriate reviewer(s).

Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including subject-matter experts and editing/style reviewers.
