### PR TITLE
Include issue details in OrchestrateClientErrors

### DIFF
--- a/python/tests/test_http_handler.py
+++ b/python/tests/test_http_handler.py
@@ -157,6 +157,14 @@ _OUTCOME_POST_TEST_DATA = [
         "Expected a Bundle but found a Patient",
         id="zip",
     ),
+    pytest.param(
+        "application/hl7-v2+er7",
+        "application/json",
+        "/convert/v1/hl7tofhirr4",
+        "MSH|^~\&||CHOA|||20251006103053||ADT^A40|156753805|P|2.5.1|InsertSequenceNumberHere",
+        "Message type 'ADT^A40' is not supported",
+        id="hl7",
+    ),
 ]
 
 

--- a/typescript/tests/httpHandler.test.ts
+++ b/typescript/tests/httpHandler.test.ts
@@ -54,6 +54,14 @@ describe.concurrent("httpHandler outcomes", () => {
       expectedMessage: "Expected a Bundle but found a Patient",
       id: "zip",
     },
+    {
+      contentType: "application/hl7-v2+er7",
+      accept: "application/json",
+      route: "/convert/v1/hl7tofhirr4",
+      body: "MSH|^~\&||CHOA|||20251006103053||ADT^A40|156753805|P|2.5.1|InsertSequenceNumberHere",
+      expectedMessage: "Message type 'ADT^A40' is not supported",
+      id: "hl7",
+    },
   ];
   const cases = testCases.map((input) => ({ input }));
 
@@ -71,7 +79,7 @@ describe.concurrent("httpHandler outcomes", () => {
   test.each(cases)("should classify single $input.id", async ({ input }: { input: OutcomeTestCase }) => {
     const { contentType, accept, route, body, expectedMessage } = input;
 
-    expect(async () => {
+    await expect(async () => {
       await handler.post(route, body, { "Content-Type": contentType, Accept: accept });
     }).rejects.toThrowError(expectedMessage);
   });


### PR DESCRIPTION
## Description of Changes

HL7-to-FHIR errors look like this:
```json
{
    "resourceType": "OperationOutcome",
    "issue": [
        {
            "severity": "error",
            "code": "invalid",
            "details": {
                "coding": [
                    {
                        "system": "https://quality.rosetta.careevolution.com/v1/CodeSystems/HL7Processing",
                        "code": "UnsupportedMessageType"
                    }
                ],
                "text": "Message type 'ADT^A40' is not supported"
            }
        }
    ]
}
```

Unfortunately, the HTTP hander was ignoring the issue details and producing OrchestrateClientError with the following message:
```
Issues: 
  * error: invalid - 
```

This PR modifies the construction of the error message to take into account issue details. The above OperationOutcome now produces an exception with the following message:
```
"Issues: 
  * error: invalid - Message type 'ADT^A40' is not supported
```

## Issue Link

This PR addresses the following issues:

- https://github.com/CareEvolution/CadenceEventProcessor/issues/768

## Security

**REMINDER: All file contents are public.**

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc. Of particular note: No temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [x] My changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

## Change Control Board (CCB) Approval

> CCB approval is required when the change affects organizational processes (like vulnerability management or disaster recovery), or has the potential to impact availability, security, or privacy. See the CR process for more detailed assessment guidelines.

- [x] This change does NOT require CCB approval.
- [ ] This change DOES require CCB approval. Tag `@careevolution/ccb`.

## Testing/Validation

> Describe how we will know if the change is working as intended. Consider both pre-production testing and post-implementation validation, including environment/configuration details, if applicable.

TODO: REPLACE WITH YOUR TESTING/VALIDATION PLAN

## Backout Plan

> Describe how we will restore the system to its pre-change state if something goes wrong.

TODO: REPLACE WITH YOUR BACKOUT PLAN

## Implementation Notes

> Describe any special considerations for implementing the change: scheduling constraints, down-time planning, if a co-pilot is needed, etc.

TODO: REPLACE WITH IMPLEMENTATION NOTES

## Documentation Updates

> Describe any necessary updates. Consider both internal (wiki, checklists) and external (user guides, developer docs, customer communications) documentation.

- [x] This change has no documentation impact.
- [ ] This change impacts external documentation (API docs, user guides). Tag `@careevolution/mdhd-docs` or `@careevolution/api-docs`.
- [ ] This change impacts internal documentation (procedures, security plans, wiki). Tag the owner.

TODO: REPLACE WITH A DESCRIPTION OF DOCUMENTATION UPDATES, if applicable

## Reviewers

- [ ] I have assigned the appropriate reviewer(s).

Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including subject-matter experts and editing/style reviewers.
