### PR TITLE
Add Dependabot Cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     directory: "/python"
     schedule:
       interval: weekly
@@ -14,6 +19,11 @@ updates:
           - "minor"
           - "patch"
   - package-ecosystem: "npm"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     directory: "/typescript"
     schedule:
       interval: weekly
@@ -27,6 +37,11 @@ updates:
           - "minor"
           - "patch"
   - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     directory: "/"
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,9 +39,6 @@ updates:
   - package-ecosystem: "github-actions"
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
     directory: "/"
     schedule:
       interval: weekly


### PR DESCRIPTION
## Description of Changes

Adds a `cooldown:` block to each `package-ecosystem` entry in `.github/dependabot.yml`. Values follow the CE house style already in use by `SecurityAndChangeControl`:

Cooldown delays version-update PRs by N days after publish, giving the ecosystem time to detect and yank malicious releases. Same risk applies to the `github-actions` ecosystem (poisoned third-party action via auto-PR), hence the same block there.

```yaml
cooldown:
  default-days: 7
  semver-major-days: 30
  semver-minor-days: 7
  semver-patch-days: 3
```

Review and manually apply the following workflow permissions:
```
gh api -X PUT repos/CareEvolution/OrchestrateSDK/actions/permissions/workflow \
  -F default_workflow_permissions=read \
  -F can_approve_pull_request_reviews=false
```

Rationale: https://careevolution.slack.com/archives/C0DEKSMFY/p1779275551026199?thread_ts=1779197176.503919&cid=C0DEKSMFY

## Issue Link
N/A 

## Security

**REMINDER: All file contents are public.**

- [x] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
- [x] My changes do not introduce any security risks, or any such risks have been properly mitigated.

Defensive change; reduces same-day auto-merge risk for compromised package versions. No new attack surface.

## Change Control Board (CCB) Approval

> CCB approval is required when the change affects organizational processes (like vulnerability management or disaster recovery), or has the potential to impact availability, security, or privacy. See the CR process for more detailed assessment guidelines.

- [x] This change does NOT require CCB approval.
- [ ] This change DOES require CCB approval. Tag `@careevolution/ccb`.

## Testing/Validation

N/A 

## Backout Plan

> Describe how we will restore the system to its pre-change state if something goes wrong.

Revert the PR; Dependabot reverts to immediate version-update PRs.

## Implementation Notes

Config-only change; no downtime, no operational impact.

## Documentation Updates

- [x] This change has no documentation impact.
- [ ] This change impacts external documentation (API docs, user guides). Tag `@careevolution/mdhd-docs` or `@careevolution/api-docs`.
- [ ] This change impacts internal documentation (procedures, security plans, wiki). Tag the owner.

N/A -- internal change to `.github/dependabot.yml`.

## Reviewers

- [x] I have assigned the appropriate reviewer(s).

Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including subject-matter experts and editing/style reviewers.